### PR TITLE
feat: align frontend with spec/observation separation

### DIFF
--- a/src/app/hdt/[id]/property-live/page.tsx
+++ b/src/app/hdt/[id]/property-live/page.tsx
@@ -4,9 +4,10 @@
 import { use, useEffect, useMemo, useState } from "react";
 import LiveLineChart from "@/components/LiveLineChart";
 import { Filter } from "@/components/Filter";
-import { distinct } from "@/util/utils";
-import { PropertyEventDocument } from "@/lib/api/schema";
+import { HdtSpecResponse, PropertyObservationDocument, PropertySpecEntry } from "@/lib/api/schema";
 import { api } from "@/lib/api/client";
+
+const NUMERIC_TYPES = ["INT", "LONG", "FLOAT", "DOUBLE"];
 
 interface PropertyListItemProps {
   propertyName: string;
@@ -29,25 +30,24 @@ function PropertyListItem({ propertyName, selected, onClick }: PropertyListItemP
 
 export default function PropertyLiveUpdatePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const [dtProperties, setDtProperties] = useState<PropertyEventDocument[]>([]);
+  const [spec, setSpec] = useState<HdtSpecResponse | null>(null);
   const [selectedProperty, setSelectedProperty] = useState<string | null>(null);
   const [search, setSearch] = useState("");
-  const [propertyHistory, setPropertyHistory] = useState<PropertyEventDocument[]>([])
+  const [propertyHistory, setPropertyHistory] = useState<PropertyObservationDocument[]>([]);
 
-
-  const fetchProperties = async () => {
+  const fetchSpec = async () => {
     try {
-      const res = await api.GET("/hdts/{id}/events", {
+      const res = await api.GET("/hdts/{id}/spec", {
         params: {
           path: { id }
         }
       });
-      res.data ? setDtProperties(res.data) : setDtProperties([]);
+      setSpec(res.data ?? null);
     } catch (err) {
-      console.error("Failed to fetch DT properties:", err);
-      setDtProperties([])
+      console.error("Failed to fetch HDT spec:", err);
+      setSpec(null);
     }
-  }
+  };
 
   const fetchPropertyHistory = async (dtId: string, pName: string) => {
     try {
@@ -56,68 +56,60 @@ export default function PropertyLiveUpdatePage({ params }: { params: Promise<{ i
           hdtId: dtId,
           propertyName: pName,
         }]
-      })
-      res.data ? setPropertyHistory(res.data) : setPropertyHistory([]);
+      });
+      setPropertyHistory(res.data ?? []);
     } catch (err) {
       console.error("Failed to fetch property history:", err);
     }
   };
 
+  const numericProperties: PropertySpecEntry[] = useMemo(() =>
+    spec?.models.flatMap((m) =>
+      m.properties.filter((p) => NUMERIC_TYPES.includes(p.declaredType))
+    ) ?? [],
+    [spec]
+  );
+
   const filteredProperties = useMemo(() => {
-    return dtProperties
-        .filter((prop) => {
-          const q = search.trim();
-          if (!q) return true;
-          try {
-            const regex = new RegExp(q, "i");
-            return regex.test(prop.metaField.propertyId);
-          } catch {
-            return true;
-          }
-      })
-      .filter((p) => {
-        return typeof p.value.value === "number"
-      })
-  }, [dtProperties, search])
-    
+    const q = search.trim();
+    if (!q) return numericProperties;
+    try {
+      const regex = new RegExp(q, "i");
+      return numericProperties.filter((p) => regex.test(p.propertyName));
+    } catch {
+      return numericProperties;
+    }
+  }, [numericProperties, search]);
 
-  const propertyNames = useMemo(() => {
-    return distinct(
-      filteredProperties.map((p) => p.metaField.propertyName)
-    )
-  }, [filteredProperties])
-
-  // Select first one as default
   useEffect(() => {
-    fetchProperties()
+    fetchSpec();
 
     if (!selectedProperty) {
-      setSelectedProperty(propertyNames[0] || null);
+      setSelectedProperty(filteredProperties[0]?.propertyName ?? null);
     }
   }, [id]);
 
   return (
     <div className="flex w-full h-full p-4 gap-4">
       {/* Left - Property list */}
-    <div className="w-1/4 bg-gray-900 rounded p-2 overflow-auto max-h-screen">
-      <h2 className="font-bold text-white mb-2">Properties</h2>
+      <div className="w-1/4 bg-gray-900 rounded p-2 overflow-auto max-h-screen">
+        <h2 className="font-bold text-white mb-2">Properties</h2>
 
-      <Filter
-        value={search}
-        onChange={setSearch}
-        placeholder="Search properties..."
-        className="mb-2 p-2 border border-gray-700 rounded bg-gray-800 text-white w-full"
-      />
+        <Filter
+          value={search}
+          onChange={setSearch}
+          placeholder="Search properties..."
+          className="mb-2 p-2 border border-gray-700 rounded bg-gray-800 text-white w-full"
+        />
 
-      {filteredProperties.map((e) => (
-
+        {filteredProperties.map((p) => (
           <PropertyListItem
-            key={e.metaField.propertyId}
-            propertyName={e.metaField.propertyName}
-            selected={e.metaField.propertyId === selectedProperty}
+            key={p.propertyId}
+            propertyName={p.propertyName}
+            selected={p.propertyName === selectedProperty}
             onClick={() => {
-              fetchPropertyHistory(e.metaField.hdtId, e.metaField.propertyName)
-              setSelectedProperty(e.metaField.propertyName)
+              fetchPropertyHistory(id, p.propertyName);
+              setSelectedProperty(p.propertyName);
             }}
           />
         ))}
@@ -129,8 +121,7 @@ export default function PropertyLiveUpdatePage({ params }: { params: Promise<{ i
           Live Chart for <span className="text-blue-300">{selectedProperty}</span>
         </h2>
 
-        {selectedProperty ? 
-          (
+        {selectedProperty ? (
           <LiveLineChart
             dtId={id}
             pName={selectedProperty}

--- a/src/components/HdtDetail.tsx
+++ b/src/components/HdtDetail.tsx
@@ -5,71 +5,95 @@ import { useEffect, useMemo, useState } from "react";
 import { Filter } from "./Filter";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
-import { ModelDocument, PropertyEventDocument } from "@/lib/api/schema";
+import { HdtSpecResponse, PropertySnapshotEntry, PropertyValue } from "@/lib/api/schema";
 import { api } from "@/lib/api/client";
 
 interface HdtDetailProps {
   id: string;
 }
 
+type DisplayRow = {
+  modelName: string;
+  propertyId: string;
+  propertyName: string;
+  value: PropertyValue | null | undefined;
+  timestamp: string | null | undefined;
+};
+
 export default function HdtDetail({ id }: HdtDetailProps) {
-  const [state, setState] = useState<PropertyEventDocument[]>([]);
-  const [models, setModels] = useState<ModelDocument[]>([]);
+  const [spec, setSpec] = useState<HdtSpecResponse | null>(null);
+  const [snapshot, setSnapshot] = useState<PropertySnapshotEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
   const [search, setSearch] = useState("");
   const [selectedModelName, setSelectedModelName] = useState<string>("All");
 
-  const fetchState = async () => {
+  const fetchSpec = async () => {
     try {
-      const res = await api.GET("/hdts/{id}/events",  {
-        params: { 
+      const res = await api.GET("/hdts/{id}/spec", {
+        params: {
           path: { id }
         }
       });
-      res.data ? setState(res.data) : setState([]);
+      const data = res.data;
+      if (data) {
+        setSpec(data);
+        setSelectedModelName((prev) =>
+          prev === "All" || data.models.some((m) => m.modelName === prev) ? prev : "All"
+        );
+      }
     } catch (err) {
-      console.error("Failed to fetch DT state:", err);
+      console.error("Failed to fetch HDT spec:", err);
     } finally {
       setLoading(false);
     }
   };
 
-  const fetchModels = async () => {
+  const fetchSnapshot = async () => {
     try {
-      const res = await api.GET("/hdts/{id}/models", {
+      const res = await api.GET("/hdts/{id}/snapshot", {
         params: {
           path: { id }
         }
       });
-      const data: ModelDocument[] = res.data || [];
-
-      setModels(data);
-
-      // Keep current selection if still valid, otherwise default to All
-      setSelectedModelName((prev) =>
-        prev === "All" || data.some((m) => m.modelName === prev) ? prev : "All"
-      );
+      setSnapshot(res.data ?? []);
     } catch (err) {
-      console.error("Failed to fetch models:", err);
+      console.error("Failed to fetch HDT snapshot:", err);
     }
-  }
+  };
 
   useEffect(() => {
-    fetchState();
-    fetchModels();
+    fetchSpec();
+    fetchSnapshot();
 
     const interval = setInterval(() => {
-      fetchState();
-    }, 5000); // Poll every 5 seconds
+      fetchSnapshot();
+    }, 5000);
 
     return () => clearInterval(interval);
   }, [id]);
 
-  const filteredProperties = useMemo(() => {
-    return state.filter((p: PropertyEventDocument) => {
+  const displayRows: DisplayRow[] = useMemo(() => {
+    if (!spec) return [];
+    const snapshotMap = new Map(snapshot.map((s) => [s.propertyId, s]));
+    return spec.models.flatMap((model) =>
+      model.properties.map((prop) => {
+        const obs = snapshotMap.get(prop.propertyId);
+        return {
+          modelName: model.modelName,
+          propertyId: prop.propertyId,
+          propertyName: prop.propertyName,
+          value: obs?.value ?? prop.initialValue,
+          timestamp: obs?.timestamp ?? null,
+        };
+      })
+    );
+  }, [spec, snapshot]);
+
+  const filteredRows = useMemo(() => {
+    return displayRows.filter((row) => {
       const matchesModel =
-        selectedModelName === "All" || p.metaField.modelName === selectedModelName;
+        selectedModelName === "All" || row.modelName === selectedModelName;
 
       if (!matchesModel) return false;
 
@@ -78,12 +102,12 @@ export default function HdtDetail({ id }: HdtDetailProps) {
 
       try {
         const regex = new RegExp(q, "i");
-        return regex.test(p.metaField.propertyName);
+        return regex.test(row.propertyName);
       } catch {
         return true;
       }
     });
-  }, [state, selectedModelName, search])
+  }, [displayRows, selectedModelName, search]);
 
   return (
     <div className="bg-gray-900 text-white p-4 rounded shadow w-full">
@@ -122,7 +146,7 @@ export default function HdtDetail({ id }: HdtDetailProps) {
               }}
             >
               <Tab value="All" label="All" />
-              {models.map((m) => (
+              {spec?.models.map((m) => (
                 <Tab key={m.modelId} value={m.modelName} label={m.modelName} />
               ))}
             </Tabs>
@@ -146,25 +170,24 @@ export default function HdtDetail({ id }: HdtDetailProps) {
                 </tr>
               </thead>
               <tbody>
-                {filteredProperties.map((prop: PropertyEventDocument) => {
-                  const modelId = prop.metaField.modelId;
-                  const propertyId = prop.metaField.propertyId;
-                  const propertyName = prop.metaField.propertyName;
-                  const timestamp = new Date(prop.timeField);
-
-                  return (
-                    <tr
-                      key={propertyId}
-                      className="bg-gray-900 hover:bg-gray-800"
-                      onClick={() => router.push(`/hdt/${id}/property-live`)}
-                    >
-                      <td className="p-2 border border-gray-700">{modelId}</td>
-                      <td className="p-2 border border-gray-700">{propertyName}</td>
-                      <td className="p-2 border border-gray-700">{prop.value.value?.toString()}</td>
-                      <td className="p-2 border border-gray-700">{timestamp.toDateString()}</td>
-                    </tr>
-                  );
-                })}
+                {filteredRows.map((row) => (
+                  <tr
+                    key={row.propertyId}
+                    className="bg-gray-900 hover:bg-gray-800"
+                    onClick={() => router.push(`/hdt/${id}/property-live`)}
+                  >
+                    <td className="p-2 border border-gray-700">{row.modelName}</td>
+                    <td className="p-2 border border-gray-700">{row.propertyName}</td>
+                    <td className="p-2 border border-gray-700">
+                      {row.value != null
+                        ? String((row.value as { value?: unknown }).value ?? "—")
+                        : "—"}
+                    </td>
+                    <td className="p-2 border border-gray-700">
+                      {row.timestamp ? new Date(row.timestamp).toDateString() : "—"}
+                    </td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>

--- a/src/components/LiveLineChart.tsx
+++ b/src/components/LiveLineChart.tsx
@@ -8,12 +8,12 @@ import {
   Tooltip,
   ResponsiveContainer
 } from "recharts";
-import { PropertyEventDocument } from "@/lib/api/schema";
+import { PropertyObservationDocument } from "@/lib/api/schema";
 
 interface LiveLineChartProps {
   dtId: string;
   pName: string;
-  history: PropertyEventDocument[]
+  history: PropertyObservationDocument[]
 }
 
 export default function LiveLineChart({ dtId, pName, history }: LiveLineChartProps) {

--- a/src/lib/api/schema.d.ts
+++ b/src/lib/api/schema.d.ts
@@ -84,10 +84,50 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get HDT's [Events]
-         * @description Get all Events of the specified HDT
+         * Get HDT's [Observations]
+         * @description Get all Observations of the specified HDT
          */
         get: operations["hdts/{id}/events"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/hdts/{id}/spec": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get full HDT spec
+         * @description Assembles a full HDT spec from hdt, models, and properties collections
+         */
+        get: operations["hdts/{id}/spec"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/hdts/{id}/snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get HDT snapshot
+         * @description Returns current value per property — latest observation or initialValue fallback
+         */
+        get: operations["hdts/{id}/snapshot"];
         put?: never;
         post?: never;
         delete?: never;
@@ -172,6 +212,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/properties": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Property specs
+         * @description Return property specs filtered by hdtId and optional modelId
+         */
+        get: operations["properties/get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/properties/batch": {
         parameters: {
             query?: never;
@@ -182,10 +242,30 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * properties/insert
-         * @description Batch insert HDT's [Property] as Events
+         * Batch upsert Property specs
+         * @description Insert or update a list of Property specs for a given HDT
          */
-        post: operations["properties/insert"];
+        post: operations["properties/batch/upsert"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/observations/batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch insert [PropertyObservation]
+         * @description Batch insert PropertyObservation
+         */
+        post: operations["observations/batch/insert"];
         delete?: never;
         options?: never;
         head?: never;
@@ -201,7 +281,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Query Events by Id */
+        /** Query Observations by Id */
         post: operations["query/event/values/byId"];
         delete?: never;
         options?: never;
@@ -218,7 +298,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Query Events by Name */
+        /** Query Observations by Name */
         post: operations["query/event/values/byName"];
         delete?: never;
         options?: never;
@@ -235,7 +315,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Query Event history for a certain HDT */
+        /** Query Observation history for a certain HDT */
         post: operations["query/event/values/history"];
         delete?: never;
         options?: never;
@@ -269,7 +349,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Query Events by comparisons */
+        /** Query Observations by comparisons */
         post: operations["query/event/comparison"];
         delete?: never;
         options?: never;
@@ -400,6 +480,22 @@ export interface components {
             /** Format: date-time */
             lastUpdated?: string;
         };
+        /** io.github.whdt.db.property.PropertyDocument */
+        PropertyDocument: {
+            hdtId: string;
+            modelId: string;
+            propertyId: string;
+            propertyName: string;
+            description: string;
+            /** @enum {string} */
+            declaredType: "INT" | "LONG" | "FLOAT" | "DOUBLE" | "STRING" | "BOOLEAN";
+            initialValue?: components["schemas"]["PropertyValue"] | null;
+            metadata?: {
+                [key: string]: string;
+            };
+            /** Format: date-time */
+            lastUpdated?: string;
+        };
         /** io.github.whdt.db.property.PropertyEventMetadata */
         PropertyEventMetadata: {
             hdtId: string;
@@ -436,22 +532,73 @@ export interface components {
         };
         /** io.github.whdt.core.hdt.model.property.PropertyValue */
         PropertyValue: components["schemas"]["boolean-value"] | components["schemas"]["double-value"] | components["schemas"]["empty-value"] | components["schemas"]["float-value"] | components["schemas"]["int-value"] | components["schemas"]["long-value"] | components["schemas"]["string-value"];
-        /** io.github.whdt.db.property.PropertyEventDocument */
-        PropertyEventDocument: {
+        /** io.github.whdt.db.property.PropertyObservationDocument */
+        PropertyObservationDocument: {
             metaField: components["schemas"]["PropertyEventMetadata"];
             /** Format: date-time */
             timeField: string;
             value: components["schemas"]["PropertyValue"];
+        };
+        /** io.github.whdt.core.hdt.model.property.PropertyObservation */
+        PropertyObservation: {
+            hdtId: string;
+            modelId: string;
+            propertyId: string;
+            propertyName: string;
+            value: components["schemas"]["PropertyValue"];
+            /** Format: date-time */
+            timestamp: string;
+            metadata?: {
+                [key: string]: string;
+            };
         };
         /** property */
         property: {
             modelId: string;
             name: string;
             description: string;
-            /** Format: date-time */
-            timestamp: string;
-            value: components["schemas"]["PropertyValue"];
+            /** @enum {string} */
+            declaredType: "INT" | "LONG" | "FLOAT" | "DOUBLE" | "STRING" | "BOOLEAN";
+            initialValue?: components["schemas"]["PropertyValue"] | null;
             id?: string;
+        };
+        /** io.github.whdt.db.assembler.PropertySpecEntry */
+        PropertySpecEntry: {
+            propertyId: string;
+            propertyName: string;
+            description: string;
+            declaredType: string;
+            initialValue?: components["schemas"]["PropertyValue"] | null;
+            metadata?: {
+                [key: string]: string;
+            };
+        };
+        /** io.github.whdt.db.assembler.ModelSpecEntry */
+        ModelSpecEntry: {
+            modelId: string;
+            modelName: string;
+            properties: components["schemas"]["PropertySpecEntry"][];
+        };
+        /** io.github.whdt.db.assembler.HdtSpecResponse */
+        HdtSpecResponse: {
+            hdtId: string;
+            physicalInterfaces: components["schemas"]["PhysicalInterface"][];
+            digitalInterfaces: components["schemas"]["DigitalInterface"][];
+            storages: components["schemas"]["Storage"][];
+            models: components["schemas"]["ModelSpecEntry"][];
+            metadata: {
+                [key: string]: string;
+            };
+        };
+        /** io.github.whdt.db.assembler.PropertySnapshotEntry */
+        PropertySnapshotEntry: {
+            propertyId: string;
+            propertyName: string;
+            value?: components["schemas"]["PropertyValue"] | null;
+            /** Format: date-time */
+            timestamp?: string | null;
+            /** @enum {string} */
+            source: "observation" | "initial_value";
         };
         /** io.github.whdt.routing.query.event.values.PropertyValuesRequest */
         PropertyValuesRequest: {
@@ -533,6 +680,7 @@ export type HumanDigitalTwinDocument = components['schemas']['HumanDigitalTwinDo
 export type Model = components['schemas']['model'];
 export type HumanDigitalTwin = components['schemas']['human-digital-twin'];
 export type ModelDocument = components['schemas']['ModelDocument'];
+export type PropertyDocument = components['schemas']['PropertyDocument'];
 export type PropertyEventMetadata = components['schemas']['PropertyEventMetadata'];
 export type BooleanValue = components['schemas']['boolean-value'];
 export type DoubleValue = components['schemas']['double-value'];
@@ -542,8 +690,13 @@ export type IntValue = components['schemas']['int-value'];
 export type LongValue = components['schemas']['long-value'];
 export type StringValue = components['schemas']['string-value'];
 export type PropertyValue = components['schemas']['PropertyValue'];
-export type PropertyEventDocument = components['schemas']['PropertyEventDocument'];
+export type PropertyObservationDocument = components['schemas']['PropertyObservationDocument'];
+export type PropertyObservation = components['schemas']['PropertyObservation'];
 export type Property = components['schemas']['property'];
+export type PropertySpecEntry = components['schemas']['PropertySpecEntry'];
+export type ModelSpecEntry = components['schemas']['ModelSpecEntry'];
+export type HdtSpecResponse = components['schemas']['HdtSpecResponse'];
+export type PropertySnapshotEntry = components['schemas']['PropertySnapshotEntry'];
 export type PropertyValuesRequest = components['schemas']['PropertyValuesRequest'];
 export type PropertyStatsRequest = components['schemas']['PropertyStatsRequest'];
 export type PropertyStatsPerHdt = components['schemas']['PropertyStatsPerHdt'];
@@ -728,17 +881,89 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Human Digital Twin Events */
+            /** @description Human Digital Twin Observations */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PropertyEventDocument"][];
+                    "application/json": components["schemas"]["PropertyObservationDocument"][];
                 };
             };
-            /** @description Human Digital Twin or Events not found */
+            /** @description Human Digital Twin or Observations not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "hdts/{id}/spec": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Full HDT spec */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HdtSpecResponse"];
+                };
+            };
+            /** @description Missing HDT id */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description HDT or associated data not found */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "hdts/{id}/snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Property snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PropertySnapshotEntry"][];
+                };
+            };
+            /** @description Missing HDT id */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description HDT or property specs not found */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -939,28 +1164,97 @@ export interface operations {
             };
         };
     };
-    "properties/insert": {
+    "properties/get": {
         parameters: {
-            query?: never;
+            query: {
+                hdtId: string;
+                modelId?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** @description A Human Digital Twin */
+        requestBody?: never;
+        responses: {
+            /** @description Property specs */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PropertyDocument"][];
+                };
+            };
+            /** @description Missing hdtId query parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "properties/batch/upsert": {
+        parameters: {
+            query: {
+                hdtId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List of Property specs */
         requestBody: {
             content: {
-                "application/json": components["schemas"]["human-digital-twin"];
+                "application/json": components["schemas"]["property"][];
             };
         };
         responses: {
-            /** @description HDT's [Property] created as Events */
+            /** @description Property specs upserted successfully */
             201: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
             };
-            /** @description Error creating Events */
+            /** @description Missing hdtId query parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to upsert property specs */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "observations/batch/insert": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description A list of PropertyObservation */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PropertyObservation"][];
+            };
+        };
+        responses: {
+            /** @description Observations created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Error creating observations */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -988,7 +1282,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PropertyEventDocument"][];
+                    "application/json": components["schemas"]["PropertyObservationDocument"][];
                 };
             };
             /** @description POST /query/event/values/valuesById response 400 if empty request. */
@@ -1019,7 +1313,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PropertyEventDocument"][];
+                    "application/json": components["schemas"]["PropertyObservationDocument"][];
                 };
             };
             /** @description POST /query/event/values/valuesByName response 400 if empty request. */
@@ -1050,7 +1344,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PropertyEventDocument"][];
+                    "application/json": components["schemas"]["PropertyObservationDocument"][];
                 };
             };
             /** @description POST /query/event/values/history response 400 if empty request. */


### PR DESCRIPTION
Closes #13

## Summary

- Regenerated `schema.d.ts` from updated `openapi.yaml`: adds `HdtSpecResponse`, `PropertySnapshotEntry`, `PropertySpecEntry`, `ModelSpecEntry`, `PropertyObservationDocument`; removes `PropertyEventDocument`; adds new endpoints `/hdts/{id}/spec` and `/hdts/{id}/snapshot`
- `HdtDetail`: replaced `GET /hdts/{id}/events` + `/models` with `GET /hdts/{id}/spec` (once) + `GET /hdts/{id}/snapshot` (polled every 5s), joined client-side on `propertyId`
- `property-live/page`: replaced events fetch with spec fetch, filters numeric properties by `declaredType` instead of `typeof value`
- `LiveLineChart`: renamed `PropertyEventDocument` → `PropertyObservationDocument`

## Deviations

- `gen:api:local` could not be run in CI environment (npm install blocked); schema updated manually from `openapi.yaml`
- `gen:api:local` is missing `--root-types --root-types-no-schema-prefix` flags — added manually to preserve root type exports

Generated with [Claude Code](https://claude.ai/code)