### PR TITLE
feat: re-sync with persistence-service OpenAPI v0.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ HDT creation and Excel upload bypass the typed client and use raw `fetch` agains
 
 All components use `"use client"`. There are no server components beyond the root layout.
 
-`HdtDetail` polls `/hdts/{id}/events` every 5 seconds for live property updates. The property-live page fetches history on demand via `POST /query/event/values/history`.
+`HdtDetail` polls `/hdts/{id}/snapshot` every 5 seconds for live property updates. The property-live page fetches history on demand via `POST /query/event/values/history`.
 
-`src/app/query-builder/types/query.ts` defines the local `FilterOperator` type and maps it to the backend's `PropertyComparison` comparison enum (GT, LT, EQ, GTE, LTE).
+`src/app/query-builder/types/query.ts` defines the local `FilterOperator` type and maps it to the backend's `PropertyComparisonDto` comparison enum (GT, LT, EQ, GTE, LTE).
+
+The persistence spec (v0.2.0+) uses `tags` (not `metadata`) on `HumanDigitalTwinDocument`, `ModelDocument`, `PropertyDocument`, `PropertySpecEntry`, `ModelSpecEntry`, and `HdtSpecResponse`. `PropertyObservation.metadata` is unchanged.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,1607 @@
+openapi: 3.1.1
+info:
+  title: whdt-persistence-api
+  version: v0.2.0
+paths:
+  /hdts:
+    post:
+      operationId: hdts/post
+      summary: Create HDT
+      description: Creates a new Human Digital Twin
+      requestBody:
+        description: The Representation of a Human Digital Twin
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/human-digital-twin'
+        required: true
+      responses:
+        '201':
+          description: HumanDigitalTwin created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HumanDigitalTwinDocument'
+    get:
+      operationId: hdts/get
+      summary: List HDTs
+      description: Returns all Human Digital Twins
+      responses:
+        '200':
+          description: All Human Digital Twins
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HumanDigitalTwinDocument'
+    put:
+      operationId: hdts/put
+      summary: Create or Update HDT
+      description: Creates a new Human Digital Twin or updates an existing one
+      requestBody:
+        description: The Representation of a Human Digital Twin
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/human-digital-twin'
+        required: true
+      responses:
+        '200':
+          description: HumanDigitalTwin created or updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HumanDigitalTwinDocument'
+  /hdts/{id}:
+    put:
+      operationId: hdts/{id}/update
+      summary: Update HDT
+      description: Update a Human Digital Twin
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The updated Human Digital Twin
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/human-digital-twin'
+        required: true
+      responses:
+        '200':
+          description: Human Digital Twin updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HumanDigitalTwinDocument'
+        '404':
+          description: Human Digital Twin to update not found
+    delete:
+      operationId: hdts/{id}/remove
+      summary: Remove HDT
+      description: Remove a Human Digital Twin
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Human Digital Twin removed
+        '404':
+          description: Human Digital Twin to remove not found
+    get:
+      operationId: hdts/{id}/get
+      summary: Get HDT
+      description: Get a Human Digital Twin by its ID
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Human Digital Twin found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HumanDigitalTwinDocument'
+        '404':
+          description: Human Digital Twin not found
+  /hdts/{id}/models:
+    get:
+      operationId: hdts/{id}/models
+      summary: Get HDT's Models
+      description: Get all Models of the specified HDT
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Human Digital Twin Models
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ModelDocument'
+        '404':
+          description: Human Digital Twin not found
+  /hdts/{id}/observations:
+    get:
+      operationId: hdts/{id}/observations
+      summary: Get HDT's [Observations]
+      description: Get all Observations of the specified HDT
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Human Digital Twin Observations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PropertyObservationDocument'
+        '404':
+          description: Human Digital Twin or Observations not found
+  /hdts/{id}/spec:
+    get:
+      operationId: hdts/{id}/spec
+      summary: Get full HDT spec
+      description: Assembles a full HDT spec from hdt, models, and properties collections
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Full HDT spec
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HdtSpecResponse'
+        '400':
+          description: Missing HDT id
+        '500':
+          description: HDT or associated data not found
+  /hdts/{id}/snapshot:
+    get:
+      operationId: hdts/{id}/snapshot
+      summary: Get HDT snapshot
+      description: Returns current value per property — latest observation or initialValue fallback
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Property snapshot
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PropertySnapshotEntry'
+        '400':
+          description: Missing HDT id
+        '500':
+          description: HDT or property specs not found
+  /hdts/batch:
+    put:
+      operationId: hdts/batch/update
+      summary: Batch update [HDT]
+      description: Update a list of Human Digital Twins
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/human-digital-twin'
+        required: true
+      responses:
+        '200':
+          description: Human Digital Twins updated
+        '500':
+          description: Update failed
+    post:
+      operationId: hdts/batch/insert
+      summary: Batch insert [HDT]
+      description: Insert a list of Human Digital Twins
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/human-digital-twin'
+        required: true
+      responses:
+        '200':
+          description: Human Digital Twins inserted
+        '500':
+          description: Insertion failed
+  /models:
+    put:
+      operationId: models/upsert
+      summary: Create or Update Model
+      description: Creates a new Model or updates it if already exists
+      requestBody:
+        description: The updated Model
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model'
+        required: true
+      responses:
+        '200':
+          description: Upserted Successfully
+        '500':
+          description: Failed to upsert Model
+    post:
+      operationId: models/create
+      summary: Create Model
+      description: Creates a new model
+      requestBody:
+        description: The representation of an HDT's Model
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model'
+        required: true
+      responses:
+        '201':
+          description: Created Successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelDocument'
+    get:
+      operationId: models/get
+      summary: List Models
+      description: Return all Models
+      responses:
+        '200':
+          description: All Models
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ModelDocument'
+  /models/batch:
+    put:
+      operationId: models/batch/upsert
+      summary: Batch upsert [Model]
+      description: Insert or update a list of HDT Models
+      requestBody:
+        description: The list of HDT Models
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/model'
+        required: true
+      responses:
+        '200':
+          description: Upserted Successfully
+        '500':
+          description: Failed to upsert Models
+    post:
+      operationId: models/batch/insert
+      summary: Batch insert [Model]
+      description: Insert a list of HDT Models
+      requestBody:
+        description: The list of HDT Models
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/model'
+        required: true
+      responses:
+        '201':
+          description: Created Successfully
+        '500':
+          description: Failed to create Models
+  /hdts/{id}/properties:
+    get:
+      operationId: properties/get
+      summary: List Property specs
+      description: Return property specs for the specified HDT, optionally filtered by modelId
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: modelId
+        in: query
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Property specs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PropertyDocument'
+        '400':
+          description: Missing HDT id
+  /hdts/{id}/properties/batch:
+    post:
+      operationId: properties/batch/upsert
+      summary: Batch upsert Property specs
+      description: Insert or update a list of Property specs for the specified HDT
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: List of Property specs
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/property'
+        required: true
+      responses:
+        '201':
+          description: Property specs upserted successfully
+        '400':
+          description: Missing HDT id
+        '500':
+          description: Failed to upsert property specs
+  /observations/batch:
+    post:
+      operationId: observations/batch/insert
+      summary: Batch insert [PropertyObservation]
+      description: Batch insert PropertyObservation
+      requestBody:
+        description: A list of PropertyObservation
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/PropertyObservation'
+        required: true
+      responses:
+        '201':
+          description: Observations created
+        '500':
+          description: Error creating observations
+  /query/property:
+    post:
+      operationId: query/property
+      summary: Query Property specs by tag predicate
+      description: Returns Property specs whose tags satisfy the given TagPredicate.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TagPredicate'
+        required: true
+      responses:
+        '200':
+          description: Matching Property specs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PropertyDocument'
+        '400':
+          description: Malformed TagPredicate body
+        '500':
+          description: Query failed
+  /query/event/values/valuesById:
+    post:
+      operationId: query/event/values/byId
+      summary: Query Observations by Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/PropertyValuesRequest'
+        required: true
+      responses:
+        '200':
+          description: POST /query/event/values/valuesById response 200
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PropertyObservationDocument'
+        '400':
+          description: POST /query/event/values/valuesById response 400 if empty request.
+  /query/event/values/valuesByName:
+    post:
+      operationId: query/event/values/byName
+      summary: Query Observations by Name
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/PropertyValuesRequest'
+        required: true
+      responses:
+        '200':
+          description: POST /query/event/values/valuesByName response 200
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PropertyObservationDocument'
+        '400':
+          description: POST /query/event/values/valuesByName response 400 if empty request.
+  /query/event/values/history:
+    post:
+      operationId: query/event/values/history
+      summary: Query Observation history for a certain HDT
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/PropertyValuesRequest'
+        required: true
+      responses:
+        '200':
+          description: POST /query/event/values/history response 200
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PropertyObservationDocument'
+        '400':
+          description: POST /query/event/values/history response 400 if empty request.
+  /query/event/stats:
+    post:
+      operationId: query/event/stats
+      summary: Query Aggregate Stats
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PropertyStatsRequest'
+        required: true
+      responses:
+        '200':
+          description: POST /query/event/stats response 200
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PropertyStatsPerHdt'
+  /views:
+    get:
+      operationId: views/get
+      summary: List Views
+      description: Returns all stored Views
+      responses:
+        '200':
+          description: All Views
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ViewDocument'
+    post:
+      operationId: views/post
+      summary: Create View
+      description: Creates or replaces a View by name
+      requestBody:
+        description: The View spec to store
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/View'
+        required: true
+      responses:
+        '201':
+          description: View created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ViewDocument'
+  /views/{name}:
+    get:
+      operationId: views/{name}/get
+      summary: Get View
+      description: Get a View by name
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: View found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ViewDocument'
+        '404':
+          description: View not found
+    put:
+      operationId: views/{name}/put
+      summary: Upsert View
+      description: Create or replace a View by name (path name takes precedence)
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The updated View spec
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/View'
+        required: true
+      responses:
+        '200':
+          description: View upserted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ViewDocument'
+    delete:
+      operationId: views/{name}/delete
+      summary: Delete View
+      description: Delete a View by name
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: View deleted
+        '404':
+          description: View not found
+  /views/{name}/execute:
+    post:
+      operationId: views/{name}/execute
+      summary: Execute View
+      description: Run a stored View against HDTs. Empty or absent hdtIds executes against all HDTs.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Optional scope — which HDT IDs to execute against
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecuteScopeRequest'
+        required: false
+      responses:
+        '200':
+          description: ViewResult per HDT id
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/ViewResult'
+        '404':
+          description: View not found
+  /query/event/comparison:
+    post:
+      operationId: query/event/comparison
+      summary: Query Observations by comparisons
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PropertiesByComparisonsRequestDto'
+      responses:
+        '200':
+          description: POST /query/event/comparison response 200
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PropertiesByComparisonsAggregateResponse'
+components:
+  schemas:
+    TagPredicate:
+      title: io.github.whdt.core.hdt.query.TagPredicate
+      oneOf:
+        - $ref: '#/components/schemas/TagPredicate-eq'
+        - $ref: '#/components/schemas/TagPredicate-in'
+        - $ref: '#/components/schemas/TagPredicate-has'
+        - $ref: '#/components/schemas/TagPredicate-and'
+        - $ref: '#/components/schemas/TagPredicate-or'
+        - $ref: '#/components/schemas/TagPredicate-not'
+      discriminator:
+        propertyName: type
+        mapping:
+          eq:  '#/components/schemas/TagPredicate-eq'
+          in:  '#/components/schemas/TagPredicate-in'
+          has: '#/components/schemas/TagPredicate-has'
+          and: '#/components/schemas/TagPredicate-and'
+          or:  '#/components/schemas/TagPredicate-or'
+          not: '#/components/schemas/TagPredicate-not'
+    TagPredicate-eq:
+      type: object
+      title: TagPredicate-eq
+      required: [type, key, value]
+      properties:
+        type:
+          type: string
+          enum: [eq]
+        key:
+          type: string
+        value:
+          type: string
+    TagPredicate-in:
+      type: object
+      title: TagPredicate-in
+      required: [type, key, values]
+      properties:
+        type:
+          type: string
+          enum: [in]
+        key:
+          type: string
+        values:
+          type: array
+          items:
+            type: string
+    TagPredicate-has:
+      type: object
+      title: TagPredicate-has
+      required: [type, key]
+      properties:
+        type:
+          type: string
+          enum: [has]
+        key:
+          type: string
+    TagPredicate-and:
+      type: object
+      title: TagPredicate-and
+      required: [type, terms]
+      properties:
+        type:
+          type: string
+          enum: [and]
+        terms:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagPredicate'
+    TagPredicate-or:
+      type: object
+      title: TagPredicate-or
+      required: [type, terms]
+      properties:
+        type:
+          type: string
+          enum: [or]
+        terms:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagPredicate'
+    TagPredicate-not:
+      type: object
+      title: TagPredicate-not
+      required: [type, term]
+      properties:
+        type:
+          type: string
+          enum: [not]
+        term:
+          $ref: '#/components/schemas/TagPredicate'
+    PropertyComparisonDto:
+      type: object
+      required:
+        - propertyName
+        - comparison
+        - value
+      properties:
+        propertyName:
+          type: string
+        comparison:
+          type: string
+          enum: [ GT, GTE, LT, LTE, EQ ]
+        value:
+          oneOf:
+            - type: number
+            - type: string
+            - type: boolean
+    PropertiesByComparisonsRequestDto:
+      type: object
+      required:
+        - comparisons
+      properties:
+        comparisons:
+          type: array
+          items:
+            $ref: '#/components/schemas/PropertyComparisonDto'
+        modelNames:
+          type: array
+          items:
+            type: string
+          nullable: true
+        from:
+          type: string
+          format: date-time
+          nullable: true
+        to:
+          type: string
+          format: date-time
+          nullable: true
+    mqtt-physical-interface:
+      type: object
+      title: mqtt-physical-interface
+      required:
+      - hdtId
+      - name
+      properties:
+        hdtId:
+          type: string
+        name:
+          type: string
+        broker:
+          type: string
+        port:
+          type: integer
+        config:
+          type: object
+          additionalProperties:
+            type: string
+        interfaceType:
+          type: string
+          enum:
+          - MQTT
+        id:
+          type: string
+    physical-interface-impl:
+      type: object
+      title: physical-interface-impl
+      required:
+      - interfaceType
+      - hdtId
+      - name
+      properties:
+        interfaceType:
+          type: string
+          enum:
+          - MQTT
+        hdtId:
+          type: string
+        name:
+          type: string
+        config:
+          type: object
+          additionalProperties:
+            type: string
+        id:
+          type: string
+    PhysicalInterface:
+      title: io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
+      oneOf:
+      - $ref: '#/components/schemas/mqtt-physical-interface'
+      - $ref: '#/components/schemas/physical-interface-impl'
+    digital-interface-impl:
+      type: object
+      title: digital-interface-impl
+      required:
+      - interfaceType
+      - hdtId
+      - name
+      properties:
+        interfaceType:
+          type: string
+          enum:
+          - MQTT
+          - HTTP
+        hdtId:
+          type: string
+        name:
+          type: string
+        config:
+          type: object
+          additionalProperties:
+            type: string
+        id:
+          type: string
+    http-digital-interface:
+      type: object
+      title: http-digital-interface
+      required:
+      - hdtId
+      - name
+      properties:
+        hdtId:
+          type: string
+        name:
+          type: string
+        host:
+          type: string
+        port:
+          type: integer
+        config:
+          type: object
+          additionalProperties:
+            type: string
+        interfaceType:
+          type: string
+          enum:
+          - HTTP
+        id:
+          type: string
+    mqtt-digital-interface:
+      type: object
+      title: mqtt-digital-interface
+      required:
+      - hdtId
+      - name
+      properties:
+        hdtId:
+          type: string
+        name:
+          type: string
+        broker:
+          type: string
+        port:
+          type: integer
+        config:
+          type: object
+          additionalProperties:
+            type: string
+        interfaceType:
+          type: string
+          enum:
+          - MQTT
+        id:
+          type: string
+    DigitalInterface:
+      title: io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
+      oneOf:
+      - $ref: '#/components/schemas/digital-interface-impl'
+      - $ref: '#/components/schemas/http-digital-interface'
+      - $ref: '#/components/schemas/mqtt-digital-interface'
+    Storage:
+      type: object
+      title: io.github.whdt.core.hdt.storage.Storage
+      required:
+      - hdtId
+      - name
+      - storageType
+      properties:
+        hdtId:
+          type: string
+        name:
+          type: string
+        storageType:
+          type: string
+          enum:
+          - IN_MEMORY
+          - DB_MONGO
+          - DB_POSTGRESQL
+        id:
+          type: string
+    HumanDigitalTwinDocument:
+      type: object
+      title: io.github.whdt.db.hdt.HumanDigitalTwinDocument
+      required:
+      - hdtId
+      - physicalInterfaces
+      - digitalInterfaces
+      - storages
+      properties:
+        hdtId:
+          type: string
+        physicalInterfaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/PhysicalInterface'
+        digitalInterfaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/DigitalInterface'
+        storages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Storage'
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+    model:
+      type: object
+      title: model
+      required:
+      - hdtId
+      - name
+      - description
+      - properties
+      properties:
+        hdtId:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/property'
+        id:
+          type: string
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+        format:
+          type: string
+    human-digital-twin:
+      type: object
+      title: human-digital-twin
+      required:
+      - hdtId
+      properties:
+        hdtId:
+          type: string
+        models:
+          type: array
+          items:
+            $ref: '#/components/schemas/model'
+        physicalInterfaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/PhysicalInterface'
+        digitalInterfaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/DigitalInterface'
+        storages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Storage'
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+    ModelDocument:
+      type: object
+      title: io.github.whdt.db.model.ModelDocument
+      required:
+      - hdtId
+      - modelId
+      - modelName
+      - modelDescription
+      properties:
+        hdtId:
+          type: string
+        modelId:
+          type: string
+        modelName:
+          type: string
+        modelDescription:
+          type: string
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+        format:
+          type: string
+        lastUpdated:
+          type: string
+          format: date-time
+    PropertyDocument:
+      type: object
+      title: io.github.whdt.db.property.PropertyDocument
+      required:
+      - hdtId
+      - modelId
+      - propertyId
+      - propertyName
+      - description
+      - declaredType
+      properties:
+        hdtId:
+          type: string
+        modelId:
+          type: string
+        propertyId:
+          type: string
+        propertyName:
+          type: string
+        description:
+          type: string
+        declaredType:
+          type: string
+          enum:
+          - INT
+          - LONG
+          - FLOAT
+          - DOUBLE
+          - STRING
+          - BOOLEAN
+        initialValue:
+          $ref: '#/components/schemas/PropertyValue'
+          nullable: true
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+        coding:
+          $ref: '#/components/schemas/Coding'
+          nullable: true
+        lastUpdated:
+          type: string
+          format: date-time
+    PropertyEventMetadata:
+      type: object
+      title: io.github.whdt.db.property.PropertyEventMetadata
+      required:
+      - hdtId
+      - modelId
+      - modelName
+      - propertyName
+      - propertyId
+      properties:
+        hdtId:
+          type: string
+        modelId:
+          type: string
+        modelName:
+          type: string
+        propertyName:
+          type: string
+        propertyId:
+          type: string
+    boolean-value:
+      type: object
+      title: boolean-value
+      required:
+      - value
+      properties:
+        value:
+          type: boolean
+    double-value:
+      type: object
+      title: double-value
+      required:
+      - value
+      properties:
+        value:
+          type: number
+    empty-value:
+      type: object
+      title: empty-value
+      properties: {}
+    float-value:
+      type: object
+      title: float-value
+      required:
+      - value
+      properties:
+        value:
+          type: number
+    int-value:
+      type: object
+      title: int-value
+      required:
+      - value
+      properties:
+        value:
+          type: integer
+    long-value:
+      type: object
+      title: long-value
+      required:
+      - value
+      properties:
+        value:
+          type: integer
+    string-value:
+      type: object
+      title: string-value
+      required:
+      - value
+      properties:
+        value:
+          type: string
+    PropertyValue:
+      title: io.github.whdt.core.hdt.model.property.PropertyValue
+      oneOf:
+      - $ref: '#/components/schemas/boolean-value'
+      - $ref: '#/components/schemas/double-value'
+      - $ref: '#/components/schemas/empty-value'
+      - $ref: '#/components/schemas/float-value'
+      - $ref: '#/components/schemas/int-value'
+      - $ref: '#/components/schemas/long-value'
+      - $ref: '#/components/schemas/string-value'
+    Coding:
+      type: object
+      title: io.github.whdt.core.hdt.model.property.Coding
+      required:
+      - system
+      - code
+      properties:
+        system:
+          type: string
+        code:
+          type: string
+    PropertyObservationDocument:
+      type: object
+      title: io.github.whdt.db.property.PropertyObservationDocument
+      required:
+      - metaField
+      - timeField
+      - value
+      properties:
+        metaField:
+          $ref: '#/components/schemas/PropertyEventMetadata'
+        timeField:
+          type: string
+          format: date-time
+        value:
+          $ref: '#/components/schemas/PropertyValue'
+    PropertyObservation:
+      type: object
+      title: io.github.whdt.core.hdt.model.property.PropertyObservation
+      required:
+      - hdtId
+      - modelId
+      - propertyId
+      - propertyName
+      - value
+      - timestamp
+      properties:
+        hdtId:
+          type: string
+        modelId:
+          type: string
+        propertyId:
+          type: string
+        propertyName:
+          type: string
+        value:
+          $ref: '#/components/schemas/PropertyValue'
+        timestamp:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    property:
+      type: object
+      title: property
+      required:
+      - modelId
+      - name
+      - description
+      - declaredType
+      properties:
+        modelId:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        declaredType:
+          type: string
+          enum:
+          - INT
+          - LONG
+          - FLOAT
+          - DOUBLE
+          - STRING
+          - BOOLEAN
+        initialValue:
+          $ref: '#/components/schemas/PropertyValue'
+          nullable: true
+        id:
+          type: string
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+        coding:
+          $ref: '#/components/schemas/Coding'
+          nullable: true
+    PropertySpecEntry:
+      type: object
+      title: io.github.whdt.db.assembler.PropertySpecEntry
+      required:
+      - propertyId
+      - propertyName
+      - description
+      - declaredType
+      properties:
+        propertyId:
+          type: string
+        propertyName:
+          type: string
+        description:
+          type: string
+        declaredType:
+          type: string
+        initialValue:
+          $ref: '#/components/schemas/PropertyValue'
+          nullable: true
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+        coding:
+          $ref: '#/components/schemas/Coding'
+          nullable: true
+    ModelSpecEntry:
+      type: object
+      title: io.github.whdt.db.assembler.ModelSpecEntry
+      required:
+      - modelId
+      - modelName
+      - properties
+      properties:
+        modelId:
+          type: string
+        modelName:
+          type: string
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/PropertySpecEntry'
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+        format:
+          type: string
+    HdtSpecResponse:
+      type: object
+      title: io.github.whdt.db.assembler.HdtSpecResponse
+      required:
+      - hdtId
+      - physicalInterfaces
+      - digitalInterfaces
+      - storages
+      - models
+      - tags
+      properties:
+        hdtId:
+          type: string
+        physicalInterfaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/PhysicalInterface'
+        digitalInterfaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/DigitalInterface'
+        storages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Storage'
+        models:
+          type: array
+          items:
+            $ref: '#/components/schemas/ModelSpecEntry'
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+    PropertySnapshotEntry:
+      type: object
+      title: io.github.whdt.db.assembler.PropertySnapshotEntry
+      required:
+      - propertyId
+      - propertyName
+      - source
+      properties:
+        propertyId:
+          type: string
+        propertyName:
+          type: string
+        value:
+          $ref: '#/components/schemas/PropertyValue'
+          nullable: true
+        timestamp:
+          type: string
+          format: date-time
+          nullable: true
+        source:
+          type: string
+          enum:
+          - observation
+          - initial_value
+    PropertyValuesRequest:
+      type: object
+      title: io.github.whdt.routing.query.event.values.PropertyValuesRequest
+      properties:
+        hdtId:
+          type: string
+        modelId:
+          type: string
+        propertyId:
+          type: string
+        propertyName:
+          type: string
+        from:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        to:
+          type:
+          - string
+          - 'null'
+          format: date-time
+    PropertyStatsRequest:
+      type: object
+      title: io.github.whdt.routing.query.event.stats.PropertyStatsRequest
+      required:
+      - hdtIds
+      - modelIds
+      - modelNames
+      - propertyName
+      properties:
+        hdtIds:
+          type: array
+          items:
+            type: string
+        modelIds:
+          type: array
+          items:
+            type: string
+        modelNames:
+          type: array
+          items:
+            type: string
+        propertyName:
+          type: string
+        from:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        to:
+          type:
+          - string
+          - 'null'
+          format: date-time
+    PropertyStatsPerHdt:
+      type: object
+      title: io.github.whdt.routing.query.event.stats.PropertyStatsPerHdt
+      required:
+      - hdtId
+      - count
+      properties:
+        hdtId:
+          type: string
+        count:
+          type: integer
+        avg:
+          type:
+          - number
+          - 'null'
+        min:
+          type:
+          - number
+          - 'null'
+        max:
+          type:
+          - number
+          - 'null'
+    PropertyComparison:
+      type: object
+      title: io.github.whdt.routing.query.event.comparison.PropertyComparison
+      required:
+      - propertyName
+      - comparison
+      - value
+      properties:
+        propertyName:
+          type: string
+        comparison:
+          type: string
+          enum:
+          - GT
+          - GTE
+          - LT
+          - LTE
+          - EQ
+        value:
+          $ref: '#/components/schemas/PropertyValue'
+    PropertiesByComparisonsAggregateRequest:
+      type: object
+      title: io.github.whdt.routing.query.event.comparison.PropertiesByComparisonsAggregateRequest
+      required:
+      - comparisons
+      properties:
+        comparisons:
+          type: array
+          items:
+            $ref: '#/components/schemas/PropertyComparison'
+        modelNames:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+        from:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        to:
+          type:
+          - string
+          - 'null'
+          format: date-time
+    EventMatch:
+      type: object
+      title: io.github.whdt.routing.query.event.comparison.EventMatch
+      required:
+      - propertyName
+      - value
+      - timeField
+      properties:
+        propertyName:
+          type: string
+        value:
+          $ref: '#/components/schemas/PropertyValue'
+        timeField:
+          type: string
+          format: date-time
+    PropertiesByComparisonsAggregateResponse:
+      type: object
+      title: io.github.whdt.routing.query.event.comparison.PropertiesByComparisonsAggregateResponse
+      required:
+      - hdtId
+      - matchedProperties
+      - matchedEvents
+      properties:
+        hdtId:
+          type: string
+        matchedProperties:
+          type: array
+          items:
+            type: string
+        matchedEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventMatch'
+    View:
+      type: object
+      title: io.github.whdt.core.hdt.view.View
+      required:
+      - name
+      properties:
+        name:
+          type: string
+        predicate:
+          $ref: '#/components/schemas/TagPredicate'
+          nullable: true
+        groupByKeys:
+          type: array
+          items:
+            type: string
+    ViewDocument:
+      type: object
+      title: io.github.whdt.db.view.ViewDocument
+      required:
+      - name
+      properties:
+        name:
+          type: string
+        predicate:
+          $ref: '#/components/schemas/TagPredicate'
+          nullable: true
+        groupByKeys:
+          type: array
+          items:
+            type: string
+    ViewResult:
+      title: io.github.whdt.core.hdt.view.ViewResult
+      description: >
+        Result of executing a View. Either a flat list of matching properties
+        or a grouped result keyed by a tag value.
+        Observed serialized shape of ViewResult.Grouped:
+          {"type":"grouped","key":"<groupByKey>","buckets":[[<tagValue_or_null>,{"type":"flat","properties":[...]}],...]}
+        The buckets field is a list of [key, flat-result] pairs (BucketListSerializer) to support null bucket keys.
+      oneOf:
+        - $ref: '#/components/schemas/ViewResult-flat'
+        - $ref: '#/components/schemas/ViewResult-grouped'
+      discriminator:
+        propertyName: type
+        mapping:
+          flat: '#/components/schemas/ViewResult-flat'
+          grouped: '#/components/schemas/ViewResult-grouped'
+    ViewResult-flat:
+      type: object
+      title: ViewResult-flat
+      required:
+      - type
+      properties:
+        type:
+          type: string
+          enum: [flat]
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/property'
+    ViewResult-grouped:
+      type: object
+      title: ViewResult-grouped
+      required:
+      - type
+      - key
+      - buckets
+      properties:
+        type:
+          type: string
+          enum: [grouped]
+        key:
+          type: string
+        buckets:
+          type: array
+          description: List of [bucketKey, ViewResult.Flat] pairs; bucketKey may be null for properties with no value for the groupByKey tag.
+          items:
+            type: array
+            minItems: 2
+            maxItems: 2
+            prefixItems:
+              - type: string
+                nullable: true
+              - $ref: '#/components/schemas/ViewResult-flat'
+    ExecuteScopeRequest:
+      type: object
+      title: io.github.whdt.routing.view.ExecuteScopeRequest
+      properties:
+        hdtIds:
+          type: array
+          items:
+            type: string
+          description: HDT IDs to execute against. Empty or absent means all HDTs.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "gen:api": "openapi-typescript http://localhost:8081/openapi.yaml -o src/lib/api/schema.d.ts --root-types --root-types-no-schema-prefix",
-    "gen:api:local": "openapi-typescript ./openapi.yaml -o src/lib/api/schema.d.ts"
+    "gen:api:local": "openapi-typescript ./openapi.yaml -o src/lib/api/schema.d.ts --root-types --root-types-no-schema-prefix"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/src/app/query-builder/page.tsx
+++ b/src/app/query-builder/page.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { distinct } from "@/util/utils";
 import { 
   AggregateOperation, 
   FilterOperator, 
   toWhdtComparisonOp 
 } from "@/app/query-builder/types/query";
-import { 
-  PropertiesByComparisonsAggregateRequest, 
-  PropertiesByComparisonsAggregateResponse, 
-  PropertiesByComparisonsRequestDto, 
-  PropertyComparison, 
-  PropertyComparisonDto, 
-  PropertyStatsRequest 
+import {
+  PropertiesByComparisonsAggregateResponse,
+  PropertiesByComparisonsRequestDto,
+  PropertyComparisonDto,
+  PropertyStatsRequest
 } from "@/lib/api/schema";
 import { api } from "@/lib/api/client";
 
@@ -36,7 +34,7 @@ export default function QueryBuilderPage() {
   const [modelNames, setModelNames] = useState<string[]>([])
   const [loadingDts, setLoadingDts] = useState(true);
   const [filters, setFilters] = useState<FilterType[]>([]);
-  const [results, setResults] = useState<Record<string, any>[]>([]);
+  const [results, setResults] = useState<Record<string, unknown>[]>([]);
 
   const addFilter = () => {
     setFilters([...filters, { propertyName: "", op: ">", value: "" }]);
@@ -463,7 +461,7 @@ export default function QueryBuilderPage() {
                                 key={i}
                                 className="px-4 py-2"
                               >
-                                {value}
+                                {value as ReactNode}
                               </td>
                             ))}
                           </tr>

--- a/src/app/query-builder/types/query.ts
+++ b/src/app/query-builder/types/query.ts
@@ -1,11 +1,11 @@
-import { PropertyComparison } from "@/lib/api/schema";
+import { PropertyComparisonDto } from "@/lib/api/schema";
 
 // src/types/query.ts
 export type AggregateOperation = "avg" | "min" | "max";
 
 export type FilterOperator = "<" | ">" | "=" | "<=" | ">=";
 
-type ComparisonOp = PropertyComparison["comparison"];
+type ComparisonOp = PropertyComparisonDto["comparison"];
 
 export function toWhdtComparisonOp(f: FilterOperator): ComparisonOp {
   switch(f) {

--- a/src/lib/api/schema.d.ts
+++ b/src/lib/api/schema.d.ts
@@ -16,7 +16,11 @@ export interface paths {
          * @description Returns all Human Digital Twins
          */
         get: operations["hdts/get"];
-        put?: never;
+        /**
+         * Create or Update HDT
+         * @description Creates a new Human Digital Twin or updates an existing one
+         */
+        put: operations["hdts/put"];
         /**
          * Create HDT
          * @description Creates a new Human Digital Twin
@@ -76,7 +80,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/hdts/{id}/events": {
+    "/hdts/{id}/observations": {
         parameters: {
             query?: never;
             header?: never;
@@ -87,7 +91,7 @@ export interface paths {
          * Get HDT's [Observations]
          * @description Get all Observations of the specified HDT
          */
-        get: operations["hdts/{id}/events"];
+        get: operations["hdts/{id}/observations"];
         put?: never;
         post?: never;
         delete?: never;
@@ -212,7 +216,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/properties": {
+    "/hdts/{id}/properties": {
         parameters: {
             query?: never;
             header?: never;
@@ -221,7 +225,7 @@ export interface paths {
         };
         /**
          * List Property specs
-         * @description Return property specs filtered by hdtId and optional modelId
+         * @description Return property specs for the specified HDT, optionally filtered by modelId
          */
         get: operations["properties/get"];
         put?: never;
@@ -232,7 +236,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/properties/batch": {
+    "/hdts/{id}/properties/batch": {
         parameters: {
             query?: never;
             header?: never;
@@ -243,7 +247,7 @@ export interface paths {
         put?: never;
         /**
          * Batch upsert Property specs
-         * @description Insert or update a list of Property specs for a given HDT
+         * @description Insert or update a list of Property specs for the specified HDT
          */
         post: operations["properties/batch/upsert"];
         delete?: never;
@@ -266,6 +270,26 @@ export interface paths {
          * @description Batch insert PropertyObservation
          */
         post: operations["observations/batch/insert"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/query/property": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Query Property specs by tag predicate
+         * @description Returns Property specs whose tags satisfy the given TagPredicate.
+         */
+        post: operations["query/property"];
         delete?: never;
         options?: never;
         head?: never;
@@ -340,6 +364,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/views": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Views
+         * @description Returns all stored Views
+         */
+        get: operations["views/get"];
+        put?: never;
+        /**
+         * Create View
+         * @description Creates or replaces a View by name
+         */
+        post: operations["views/post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/views/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get View
+         * @description Get a View by name
+         */
+        get: operations["views/{name}/get"];
+        /**
+         * Upsert View
+         * @description Create or replace a View by name (path name takes precedence)
+         */
+        put: operations["views/{name}/put"];
+        post?: never;
+        /**
+         * Delete View
+         * @description Delete a View by name
+         */
+        delete: operations["views/{name}/delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/views/{name}/execute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Execute View
+         * @description Run a stored View against HDTs. Empty or absent hdtIds executes against all HDTs.
+         */
+        post: operations["views/{name}/execute"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/query/event/comparison": {
         parameters: {
             query?: never;
@@ -361,6 +457,64 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** io.github.whdt.core.hdt.query.TagPredicate */
+        TagPredicate: components["schemas"]["TagPredicate-eq"] | components["schemas"]["TagPredicate-in"] | components["schemas"]["TagPredicate-has"] | components["schemas"]["TagPredicate-and"] | components["schemas"]["TagPredicate-or"] | components["schemas"]["TagPredicate-not"];
+        /** TagPredicate-eq */
+        "TagPredicate-eq": {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "eq";
+            key: string;
+            value: string;
+        };
+        /** TagPredicate-in */
+        "TagPredicate-in": {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "in";
+            key: string;
+            values: string[];
+        };
+        /** TagPredicate-has */
+        "TagPredicate-has": {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "has";
+            key: string;
+        };
+        /** TagPredicate-and */
+        "TagPredicate-and": {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "and";
+            terms: components["schemas"]["TagPredicate"][];
+        };
+        /** TagPredicate-or */
+        "TagPredicate-or": {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "or";
+            terms: components["schemas"]["TagPredicate"][];
+        };
+        /** TagPredicate-not */
+        "TagPredicate-not": {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "not";
+            term: components["schemas"]["TagPredicate"];
+        };
         PropertyComparisonDto: {
             propertyName: string;
             /** @enum {string} */
@@ -454,6 +608,9 @@ export interface components {
             physicalInterfaces: components["schemas"]["PhysicalInterface"][];
             digitalInterfaces: components["schemas"]["DigitalInterface"][];
             storages: components["schemas"]["Storage"][];
+            tags?: {
+                [key: string]: string;
+            };
         };
         /** model */
         model: {
@@ -462,6 +619,10 @@ export interface components {
             description: string;
             properties: components["schemas"]["property"][];
             id?: string;
+            tags?: {
+                [key: string]: string;
+            };
+            format?: string;
         };
         /** human-digital-twin */
         "human-digital-twin": {
@@ -470,6 +631,9 @@ export interface components {
             physicalInterfaces?: components["schemas"]["PhysicalInterface"][];
             digitalInterfaces?: components["schemas"]["DigitalInterface"][];
             storages?: components["schemas"]["Storage"][];
+            tags?: {
+                [key: string]: string;
+            };
         };
         /** io.github.whdt.db.model.ModelDocument */
         ModelDocument: {
@@ -477,6 +641,10 @@ export interface components {
             modelId: string;
             modelName: string;
             modelDescription: string;
+            tags?: {
+                [key: string]: string;
+            };
+            format?: string;
             /** Format: date-time */
             lastUpdated?: string;
         };
@@ -489,10 +657,11 @@ export interface components {
             description: string;
             /** @enum {string} */
             declaredType: "INT" | "LONG" | "FLOAT" | "DOUBLE" | "STRING" | "BOOLEAN";
-            initialValue?: components["schemas"]["PropertyValue"] | null;
-            metadata?: {
+            initialValue?: components["schemas"]["PropertyValue"];
+            tags?: {
                 [key: string]: string;
             };
+            coding?: components["schemas"]["Coding"];
             /** Format: date-time */
             lastUpdated?: string;
         };
@@ -532,6 +701,11 @@ export interface components {
         };
         /** io.github.whdt.core.hdt.model.property.PropertyValue */
         PropertyValue: components["schemas"]["boolean-value"] | components["schemas"]["double-value"] | components["schemas"]["empty-value"] | components["schemas"]["float-value"] | components["schemas"]["int-value"] | components["schemas"]["long-value"] | components["schemas"]["string-value"];
+        /** io.github.whdt.core.hdt.model.property.Coding */
+        Coding: {
+            system: string;
+            code: string;
+        };
         /** io.github.whdt.db.property.PropertyObservationDocument */
         PropertyObservationDocument: {
             metaField: components["schemas"]["PropertyEventMetadata"];
@@ -559,8 +733,12 @@ export interface components {
             description: string;
             /** @enum {string} */
             declaredType: "INT" | "LONG" | "FLOAT" | "DOUBLE" | "STRING" | "BOOLEAN";
-            initialValue?: components["schemas"]["PropertyValue"] | null;
+            initialValue?: components["schemas"]["PropertyValue"];
             id?: string;
+            tags?: {
+                [key: string]: string;
+            };
+            coding?: components["schemas"]["Coding"];
         };
         /** io.github.whdt.db.assembler.PropertySpecEntry */
         PropertySpecEntry: {
@@ -568,16 +746,21 @@ export interface components {
             propertyName: string;
             description: string;
             declaredType: string;
-            initialValue?: components["schemas"]["PropertyValue"] | null;
-            metadata?: {
+            initialValue?: components["schemas"]["PropertyValue"];
+            tags?: {
                 [key: string]: string;
             };
+            coding?: components["schemas"]["Coding"];
         };
         /** io.github.whdt.db.assembler.ModelSpecEntry */
         ModelSpecEntry: {
             modelId: string;
             modelName: string;
             properties: components["schemas"]["PropertySpecEntry"][];
+            tags?: {
+                [key: string]: string;
+            };
+            format?: string;
         };
         /** io.github.whdt.db.assembler.HdtSpecResponse */
         HdtSpecResponse: {
@@ -586,7 +769,7 @@ export interface components {
             digitalInterfaces: components["schemas"]["DigitalInterface"][];
             storages: components["schemas"]["Storage"][];
             models: components["schemas"]["ModelSpecEntry"][];
-            metadata: {
+            tags: {
                 [key: string]: string;
             };
         };
@@ -594,7 +777,7 @@ export interface components {
         PropertySnapshotEntry: {
             propertyId: string;
             propertyName: string;
-            value?: components["schemas"]["PropertyValue"] | null;
+            value?: components["schemas"]["PropertyValue"];
             /** Format: date-time */
             timestamp?: string | null;
             /** @enum {string} */
@@ -659,6 +842,53 @@ export interface components {
             matchedProperties: string[];
             matchedEvents: components["schemas"]["EventMatch"][];
         };
+        /** io.github.whdt.core.hdt.view.View */
+        View: {
+            name: string;
+            predicate?: components["schemas"]["TagPredicate"];
+            groupByKeys?: string[];
+        };
+        /** io.github.whdt.db.view.ViewDocument */
+        ViewDocument: {
+            name: string;
+            predicate?: components["schemas"]["TagPredicate"];
+            groupByKeys?: string[];
+        };
+        /**
+         * io.github.whdt.core.hdt.view.ViewResult
+         * @description Result of executing a View. Either a flat list of matching properties or a grouped result keyed by a tag value. Observed serialized shape of ViewResult.Grouped:
+         *       {"type":"grouped","key":"<groupByKey>","buckets":[[<tagValue_or_null>,{"type":"flat","properties":[...]}],...]}
+         *     The buckets field is a list of [key, flat-result] pairs (BucketListSerializer) to support null bucket keys.
+         */
+        ViewResult: components["schemas"]["ViewResult-flat"] | components["schemas"]["ViewResult-grouped"];
+        /** ViewResult-flat */
+        "ViewResult-flat": {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "flat";
+            properties?: components["schemas"]["property"][];
+        };
+        /** ViewResult-grouped */
+        "ViewResult-grouped": {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "grouped";
+            key: string;
+            /** @description List of [bucketKey, ViewResult.Flat] pairs; bucketKey may be null for properties with no value for the groupByKey tag. */
+            buckets: [
+                string | null,
+                components["schemas"]["ViewResult-flat"]
+            ][];
+        };
+        /** io.github.whdt.routing.view.ExecuteScopeRequest */
+        ExecuteScopeRequest: {
+            /** @description HDT IDs to execute against. Empty or absent means all HDTs. */
+            hdtIds?: string[];
+        };
     };
     responses: never;
     parameters: never;
@@ -666,6 +896,13 @@ export interface components {
     headers: never;
     pathItems: never;
 }
+export type TagPredicate = components['schemas']['TagPredicate'];
+export type TagPredicateEq = components['schemas']['TagPredicate-eq'];
+export type TagPredicateIn = components['schemas']['TagPredicate-in'];
+export type TagPredicateHas = components['schemas']['TagPredicate-has'];
+export type TagPredicateAnd = components['schemas']['TagPredicate-and'];
+export type TagPredicateOr = components['schemas']['TagPredicate-or'];
+export type TagPredicateNot = components['schemas']['TagPredicate-not'];
 export type PropertyComparisonDto = components['schemas']['PropertyComparisonDto'];
 export type PropertiesByComparisonsRequestDto = components['schemas']['PropertiesByComparisonsRequestDto'];
 export type MqttPhysicalInterface = components['schemas']['mqtt-physical-interface'];
@@ -690,6 +927,7 @@ export type IntValue = components['schemas']['int-value'];
 export type LongValue = components['schemas']['long-value'];
 export type StringValue = components['schemas']['string-value'];
 export type PropertyValue = components['schemas']['PropertyValue'];
+export type Coding = components['schemas']['Coding'];
 export type PropertyObservationDocument = components['schemas']['PropertyObservationDocument'];
 export type PropertyObservation = components['schemas']['PropertyObservation'];
 export type Property = components['schemas']['property'];
@@ -704,6 +942,12 @@ export type PropertyComparison = components['schemas']['PropertyComparison'];
 export type PropertiesByComparisonsAggregateRequest = components['schemas']['PropertiesByComparisonsAggregateRequest'];
 export type EventMatch = components['schemas']['EventMatch'];
 export type PropertiesByComparisonsAggregateResponse = components['schemas']['PropertiesByComparisonsAggregateResponse'];
+export type View = components['schemas']['View'];
+export type ViewDocument = components['schemas']['ViewDocument'];
+export type ViewResult = components['schemas']['ViewResult'];
+export type ViewResultFlat = components['schemas']['ViewResult-flat'];
+export type ViewResultGrouped = components['schemas']['ViewResult-grouped'];
+export type ExecuteScopeRequest = components['schemas']['ExecuteScopeRequest'];
 export type $defs = Record<string, never>;
 export interface operations {
     "hdts/get": {
@@ -722,6 +966,31 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HumanDigitalTwinDocument"][];
+                };
+            };
+        };
+    };
+    "hdts/put": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description The Representation of a Human Digital Twin */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["human-digital-twin"];
+            };
+        };
+        responses: {
+            /** @description HumanDigitalTwin created or updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumanDigitalTwinDocument"];
                 };
             };
         };
@@ -870,7 +1139,7 @@ export interface operations {
             };
         };
     };
-    "hdts/{id}/events": {
+    "hdts/{id}/observations": {
         parameters: {
             query?: never;
             header?: never;
@@ -1166,12 +1435,13 @@ export interface operations {
     };
     "properties/get": {
         parameters: {
-            query: {
-                hdtId: string;
+            query?: {
                 modelId?: string;
             };
             header?: never;
-            path?: never;
+            path: {
+                id: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
@@ -1185,7 +1455,7 @@ export interface operations {
                     "application/json": components["schemas"]["PropertyDocument"][];
                 };
             };
-            /** @description Missing hdtId query parameter */
+            /** @description Missing HDT id */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -1196,11 +1466,11 @@ export interface operations {
     };
     "properties/batch/upsert": {
         parameters: {
-            query: {
-                hdtId: string;
-            };
+            query?: never;
             header?: never;
-            path?: never;
+            path: {
+                id: string;
+            };
             cookie?: never;
         };
         /** @description List of Property specs */
@@ -1217,7 +1487,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Missing hdtId query parameter */
+            /** @description Missing HDT id */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -1255,6 +1525,44 @@ export interface operations {
                 content?: never;
             };
             /** @description Error creating observations */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "query/property": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TagPredicate"];
+            };
+        };
+        responses: {
+            /** @description Matching Property specs */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PropertyDocument"][];
+                };
+            };
+            /** @description Malformed TagPredicate body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query failed */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -1377,6 +1685,170 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["PropertyStatsPerHdt"][];
                 };
+            };
+        };
+    };
+    "views/get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All Views */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ViewDocument"][];
+                };
+            };
+        };
+    };
+    "views/post": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description The View spec to store */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["View"];
+            };
+        };
+        responses: {
+            /** @description View created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ViewDocument"];
+                };
+            };
+        };
+    };
+    "views/{name}/get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description View found */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ViewDocument"];
+                };
+            };
+            /** @description View not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "views/{name}/put": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        /** @description The updated View spec */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["View"];
+            };
+        };
+        responses: {
+            /** @description View upserted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ViewDocument"];
+                };
+            };
+        };
+    };
+    "views/{name}/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description View deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description View not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "views/{name}/execute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        /** @description Optional scope — which HDT IDs to execute against */
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ExecuteScopeRequest"];
+            };
+        };
+        responses: {
+            /** @description ViewResult per HDT id */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["ViewResult"];
+                    };
+                };
+            };
+            /** @description View not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
- Fix gen:api:local script: add --root-types --root-types-no-schema-prefix
- Regenerate src/lib/api/schema.d.ts from openapi.yaml (v0.2.0)
  - /hdts/{id}/observations replaces /hdts/{id}/events
  - /views and /query/property surface added (types present, unused)
  - HdtSpecResponse.tags (required) replaces .metadata
  - Top-level named exports generated via --root-types
- Anchor ComparisonOp to PropertyComparisonDto["comparison"] in query.ts
- Remove unused PropertiesByComparisonsAggregateRequest and PropertyComparison imports from query-builder/page.tsx
- Fix @typescript-eslint/no-explicit-any in query-builder/page.tsx
- Update CLAUDE.md: snapshot polling path, PropertyComparisonDto, tags note