### PR TITLE
feat: TagPredicate builder + Property tag search tab

### DIFF
--- a/src/app/query-builder/QueryWorkbench.tsx
+++ b/src/app/query-builder/QueryWorkbench.tsx
@@ -2,11 +2,13 @@
 
 import { useState } from "react";
 import { ObservationQueryPanel } from "./panels/ObservationQueryPanel";
+import { PropertyTagQueryPanel } from "./panels/PropertyTagQueryPanel";
 
-type TabKey = "observation";
+type TabKey = "observation" | "property";
 
 const TABS: { key: TabKey; label: string }[] = [
   { key: "observation", label: "Observation" },
+  { key: "property", label: "Property" },
 ];
 
 export default function QueryWorkbench() {
@@ -34,6 +36,7 @@ export default function QueryWorkbench() {
         </div>
 
         {activeTab === "observation" && <ObservationQueryPanel />}
+        {activeTab === "property" && <PropertyTagQueryPanel />}
       </div>
     </div>
   );

--- a/src/app/query-builder/panels/PropertyTagQueryPanel.tsx
+++ b/src/app/query-builder/panels/PropertyTagQueryPanel.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { TagPredicate } from "@/lib/api/schema";
+import { api } from "@/lib/api/client";
+import { TagPredicateBuilder } from "@/components/query/TagPredicateBuilder";
+import { PropertyTable } from "@/components/query/PropertyTable";
+import { fromPropertyDocument, PropertyRow } from "@/components/query/propertyRow";
+
+export function PropertyTagQueryPanel() {
+  const [predicate, setPredicate] = useState<TagPredicate | null>(null);
+  const [results, setResults] = useState<PropertyRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [empty, setEmpty] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!predicate) {
+      setError("Please define a predicate before running the query.");
+      return;
+    }
+
+    setError(null);
+    setEmpty(false);
+    setResults([]);
+    setLoading(true);
+
+    try {
+      const { data, error: err } = await api.POST("/query/property", {
+        body: predicate,
+      });
+
+      if (err) {
+        setError("Request failed");
+        return;
+      }
+
+      if (!data || data.length === 0) {
+        setEmpty(true);
+        return;
+      }
+
+      setResults(data.map(fromPropertyDocument));
+    } catch {
+      setError("Unexpected error occurred.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex gap-8 items-start">
+      <div className="w-1/2">
+        <div className="mb-4">
+          <label className="block mb-2 font-semibold">Tag Predicate</label>
+          <TagPredicateBuilder value={predicate} onChange={setPredicate} />
+        </div>
+
+        <button
+          onClick={handleSubmit}
+          disabled={loading}
+          className="w-full bg-blue-600 hover:bg-blue-500 disabled:opacity-50 transition px-6 py-3 rounded-lg font-semibold"
+        >
+          {loading ? "Running…" : "Run Query"}
+        </button>
+      </div>
+
+      <div className="w-1/2">
+        {error && (
+          <div className="p-4 bg-red-900 border border-red-600 rounded-lg mb-4 text-red-200">
+            {error}
+          </div>
+        )}
+
+        {empty && !error && (
+          <div className="p-4 bg-gray-700 rounded-lg mb-4 text-gray-400 text-center">
+            No properties found.
+          </div>
+        )}
+
+        {results.length > 0 && (
+          <div>
+            <h2 className="text-lg font-bold mb-4">Matching Properties</h2>
+            <PropertyTable rows={results} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/query/PropertyTable.tsx
+++ b/src/components/query/PropertyTable.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { PropertyRow } from "./propertyRow";
+
+export function PropertyTable({ rows }: { rows: PropertyRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <div className="p-4 bg-gray-700 rounded-lg text-gray-400 text-center">
+        No properties found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm rounded-lg overflow-hidden shadow-md">
+        <thead className="bg-gray-700">
+          <tr>
+            <th className="px-4 py-2 text-left">Name</th>
+            <th className="px-4 py-2 text-left">Model</th>
+            <th className="px-4 py-2 text-left">Type</th>
+            <th className="px-4 py-2 text-left">Tags</th>
+            <th className="px-4 py-2 text-left">Coding</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={row.id ?? i} className="border-t border-gray-700 hover:bg-gray-700">
+              <td className="px-4 py-2">{row.name}</td>
+              <td className="px-4 py-2">{row.modelId}</td>
+              <td className="px-4 py-2">{row.declaredType}</td>
+              <td className="px-4 py-2">
+                {Object.entries(row.tags).length > 0
+                  ? Object.entries(row.tags)
+                      .map(([k, v]) => `${k}=${v}`)
+                      .join(", ")
+                  : <span className="text-gray-400">—</span>}
+              </td>
+              <td className="px-4 py-2">
+                {row.coding
+                  ? `${row.coding.system}:${row.coding.code}`
+                  : <span className="text-gray-400">—</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/query/TagPredicateBuilder.tsx
+++ b/src/components/query/TagPredicateBuilder.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { type ReactElement } from "react";
+import { TagPredicate } from "@/lib/api/schema";
+
+type VariantKey = "eq" | "in" | "has" | "and" | "or" | "not";
+
+const VARIANTS: VariantKey[] = ["eq", "in", "has", "and", "or", "not"];
+
+interface TagPredicateBuilderProps {
+  value: TagPredicate | null;
+  onChange: (next: TagPredicate | null) => void;
+}
+
+export function TagPredicateBuilder({ value, onChange }: TagPredicateBuilderProps): ReactElement {
+  const currentType: VariantKey | "none" = value?.type ?? "none";
+
+  const handleTypeChange = (newType: string) => {
+    if (newType === "none") {
+      onChange(null);
+      return;
+    }
+
+    const prevKey = value && "key" in value ? value.key : "";
+
+    switch (newType as VariantKey) {
+      case "eq":
+        onChange({ type: "eq", key: prevKey, value: "" });
+        break;
+      case "in":
+        onChange({ type: "in", key: prevKey, values: [] });
+        break;
+      case "has":
+        onChange({ type: "has", key: prevKey });
+        break;
+      case "and":
+        onChange({ type: "and", terms: [] });
+        break;
+      case "or":
+        onChange({ type: "or", terms: [] });
+        break;
+      case "not":
+        onChange({ type: "not", term: { type: "has", key: "" } });
+        break;
+    }
+  };
+
+  const updateTerm = (
+    base: { type: "and"; terms: TagPredicate[] } | { type: "or"; terms: TagPredicate[] },
+    i: number,
+    next: TagPredicate | null
+  ) => {
+    const terms = [...base.terms];
+    if (next === null) {
+      terms.splice(i, 1);
+    } else {
+      terms[i] = next;
+    }
+    onChange({ ...base, terms });
+  };
+
+  const removeTerm = (
+    base: { type: "and"; terms: TagPredicate[] } | { type: "or"; terms: TagPredicate[] },
+    i: number
+  ) => {
+    const terms = base.terms.filter((_, j) => j !== i);
+    onChange({ ...base, terms });
+  };
+
+  const addTerm = (
+    base: { type: "and"; terms: TagPredicate[] } | { type: "or"; terms: TagPredicate[] }
+  ) => {
+    onChange({ ...base, terms: [...base.terms, { type: "has", key: "" }] });
+  };
+
+  return (
+    <div className="border border-gray-600 rounded p-3 bg-gray-800">
+      <select
+        className="mb-2 p-1 bg-gray-700 border border-gray-600 rounded text-sm"
+        value={currentType}
+        onChange={(e) => handleTypeChange(e.target.value)}
+      >
+        <option value="none">— none —</option>
+        {VARIANTS.map((v) => (
+          <option key={v} value={v}>
+            {v}
+          </option>
+        ))}
+      </select>
+
+      {value?.type === "eq" && (
+        <div className="flex gap-2 mt-1">
+          <input
+            className="p-1 bg-gray-700 border border-gray-600 rounded text-sm flex-1"
+            placeholder="key"
+            value={value.key}
+            onChange={(e) => onChange({ ...value, key: e.target.value })}
+          />
+          <input
+            className="p-1 bg-gray-700 border border-gray-600 rounded text-sm flex-1"
+            placeholder="value"
+            value={value.value}
+            onChange={(e) => onChange({ ...value, value: e.target.value })}
+          />
+        </div>
+      )}
+
+      {value?.type === "in" && (
+        <div className="mt-1 space-y-1">
+          <input
+            className="p-1 bg-gray-700 border border-gray-600 rounded text-sm w-full"
+            placeholder="key"
+            value={value.key}
+            onChange={(e) => onChange({ ...value, key: e.target.value })}
+          />
+          <input
+            className="p-1 bg-gray-700 border border-gray-600 rounded text-sm w-full"
+            placeholder="values (comma-separated)"
+            value={value.values.join(",")}
+            onChange={(e) =>
+              onChange({
+                ...value,
+                values: e.target.value
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean),
+              })
+            }
+          />
+        </div>
+      )}
+
+      {value?.type === "has" && (
+        <input
+          className="mt-1 p-1 bg-gray-700 border border-gray-600 rounded text-sm w-full"
+          placeholder="key"
+          value={value.key}
+          onChange={(e) => onChange({ ...value, key: e.target.value })}
+        />
+      )}
+
+      {(value?.type === "and" || value?.type === "or") && (
+        <div className="mt-2 space-y-2 pl-3 border-l border-gray-600">
+          {value.terms.map((term, i) => (
+            <div key={i} className="flex gap-2 items-start">
+              <div className="flex-1">
+                <TagPredicateBuilder
+                  value={term}
+                  onChange={(next) => updateTerm(value, i, next)}
+                />
+              </div>
+              <button
+                className="mt-1 bg-red-700 hover:bg-red-600 px-2 py-1 rounded text-xs"
+                onClick={() => removeTerm(value, i)}
+              >
+                X
+              </button>
+            </div>
+          ))}
+          <button
+            className="mt-1 bg-green-700 hover:bg-green-600 px-2 py-1 rounded text-xs"
+            onClick={() => addTerm(value)}
+          >
+            + Add Term
+          </button>
+        </div>
+      )}
+
+      {value?.type === "not" && (
+        <div className="mt-2 pl-3 border-l border-gray-600">
+          <TagPredicateBuilder
+            value={value.term}
+            onChange={(next) =>
+              onChange({ ...value, term: next ?? { type: "has", key: "" } })
+            }
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/query/propertyRow.ts
+++ b/src/components/query/propertyRow.ts
@@ -1,0 +1,23 @@
+import { PropertyDocument } from "@/lib/api/schema";
+
+export type PropertyRow = {
+  id?: string;
+  name: string;
+  modelId: string;
+  declaredType: string;
+  tags: Record<string, string>;
+  coding?: { system: string; code: string };
+  hdtId?: string;
+};
+
+export function fromPropertyDocument(d: PropertyDocument): PropertyRow {
+  return {
+    id: d.propertyId,
+    name: d.propertyName,
+    modelId: d.modelId,
+    declaredType: d.declaredType,
+    tags: d.tags ?? {},
+    coding: d.coding,
+    hdtId: d.hdtId,
+  };
+}


### PR DESCRIPTION
Closes #22

## Changes

- `src/components/query/propertyRow.ts` — `PropertyRow` view-model + `fromPropertyDocument` adapter normalizing `PropertyDocument` fields
- `src/components/query/PropertyTable.tsx` — renders `PropertyRow[]` with name/model/type/tags/coding columns
- `src/components/query/TagPredicateBuilder.tsx` — recursive editor for all 6 `TagPredicate` variants (eq/in/has/and/or/not)
- `src/app/query-builder/panels/PropertyTagQueryPanel.tsx` — wires builder → `POST /query/property` → `PropertyTable`
- `src/app/query-builder/QueryWorkbench.tsx` — registers `"property"` tab

`npm run lint` and `npm run build` both pass.

Generated with [Claude Code](https://claude.ai/code)