### PR TITLE
feat: PropertyTagEditor + tag affordance in HdtDetail

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -378,6 +378,47 @@ paths:
           description: Missing HDT id
         '500':
           description: Failed to upsert property specs
+  /hdts/{id}/properties/{propertyId}/tags:
+    put:
+      summary: Replace Property tags
+      description: >-
+        Replaces the entire tag map of a single Property spec. The request body is
+        the complete desired tag map; an empty object clears all tags.
+      operationId: properties/{propertyId}/tags/put
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: propertyId
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        '200':
+          description: Tags replaced; returns the new tag map
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+        '400':
+          description: Missing path parameter
+        '404':
+          description: Property not found
+        '500':
+          description: Failed to update tags
   /observations/batch:
     post:
       operationId: observations/batch/insert

--- a/src/components/HdtDetail.tsx
+++ b/src/components/HdtDetail.tsx
@@ -7,6 +7,7 @@ import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import { HdtSpecResponse, PropertySnapshotEntry, PropertyValue } from "@/lib/api/schema";
 import { api } from "@/lib/api/client";
+import PropertyTagEditor from "./PropertyTagEditor";
 
 interface HdtDetailProps {
   id: string;
@@ -18,6 +19,7 @@ type DisplayRow = {
   propertyName: string;
   value: PropertyValue | null | undefined;
   timestamp: string | null | undefined;
+  tags: Record<string, string>;
 };
 
 export default function HdtDetail({ id }: HdtDetailProps) {
@@ -27,6 +29,7 @@ export default function HdtDetail({ id }: HdtDetailProps) {
   const router = useRouter();
   const [search, setSearch] = useState("");
   const [selectedModelName, setSelectedModelName] = useState<string>("All");
+  const [editorTarget, setEditorTarget] = useState<DisplayRow | null>(null);
 
   const fetchSpec = async () => {
     try {
@@ -85,6 +88,7 @@ export default function HdtDetail({ id }: HdtDetailProps) {
           propertyName: prop.propertyName,
           value: obs?.value ?? prop.initialValue,
           timestamp: obs?.timestamp ?? null,
+          tags: prop.tags ?? {},
         };
       })
     );
@@ -167,6 +171,7 @@ export default function HdtDetail({ id }: HdtDetailProps) {
                   <th className="p-2 border border-gray-600">Property</th>
                   <th className="p-2 border border-gray-600">Value</th>
                   <th className="p-2 border border-gray-600">Timestamp</th>
+                  <th className="p-2 border border-gray-600">Tags</th>
                 </tr>
               </thead>
               <tbody>
@@ -186,11 +191,30 @@ export default function HdtDetail({ id }: HdtDetailProps) {
                     <td className="p-2 border border-gray-700">
                       {row.timestamp ? new Date(row.timestamp).toDateString() : "—"}
                     </td>
+                    <td className="p-2 border border-gray-700">
+                      <button
+                        className="px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 text-xs"
+                        onClick={(e) => { e.stopPropagation(); setEditorTarget(row); }}
+                      >
+                        🏷 {Object.keys(row.tags).length}
+                      </button>
+                    </td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
+          {editorTarget && (
+            <PropertyTagEditor
+              open={!!editorTarget}
+              hdtId={id}
+              propertyId={editorTarget.propertyId}
+              propertyName={editorTarget.propertyName}
+              initialTags={editorTarget.tags}
+              onClose={() => setEditorTarget(null)}
+              onSaved={() => { fetchSpec(); setEditorTarget(null); }}
+            />
+          )}
         </>
       )}
     </div>

--- a/src/components/PropertyTagEditor.tsx
+++ b/src/components/PropertyTagEditor.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import TextField from "@mui/material/TextField";
+import IconButton from "@mui/material/IconButton";
+import Button from "@mui/material/Button";
+import { api } from "@/lib/api/client";
+
+interface PropertyTagEditorProps {
+  hdtId: string;
+  propertyId: string;
+  propertyName: string;
+  initialTags: Record<string, string>;
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export default function PropertyTagEditor({
+  hdtId,
+  propertyId,
+  propertyName,
+  initialTags,
+  open,
+  onClose,
+  onSaved,
+}: PropertyTagEditorProps) {
+  const [rows, setRows] = useState<{ key: string; value: string }[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setRows(Object.entries(initialTags).map(([key, value]) => ({ key, value })));
+      setError(null);
+    }
+  }, [open, initialTags]);
+
+  const updateRow = (index: number, field: "key" | "value", val: string) => {
+    setRows((prev) => prev.map((r, i) => (i === index ? { ...r, [field]: val } : r)));
+  };
+
+  const removeRow = (index: number) => {
+    setRows((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const addRow = () => {
+    setRows((prev) => [...prev, { key: "", value: "" }]);
+  };
+
+  const handleSave = async () => {
+    const keys = rows.map((r) => r.key.trim());
+    if (keys.some((k) => k === "")) {
+      setError("Tag keys cannot be empty.");
+      return;
+    }
+    if (new Set(keys).size !== keys.length) {
+      setError("Duplicate tag keys are not allowed.");
+      return;
+    }
+
+    const body = Object.fromEntries(rows.map((r) => [r.key.trim(), r.value]));
+    setSaving(true);
+    setError(null);
+    const { error: err } = await api.PUT("/hdts/{id}/properties/{propertyId}/tags", {
+      params: { path: { id: hdtId, propertyId } },
+      body,
+    });
+    setSaving(false);
+    if (err) {
+      setError("Failed to save tags.");
+      return;
+    }
+    onSaved();
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{
+        sx: {
+          bgcolor: "#111827",
+          color: "#fff",
+          border: "1px solid #374151",
+        },
+      }}
+    >
+      <DialogTitle sx={{ color: "#fff", borderBottom: "1px solid #374151" }}>
+        Tags — {propertyName}
+      </DialogTitle>
+      <DialogContent sx={{ pt: 2 }}>
+        {error && (
+          <div className="mb-3 p-3 bg-red-900 border border-red-600 rounded text-red-200 text-sm">
+            {error}
+          </div>
+        )}
+        <div className="space-y-2">
+          {rows.map((row, i) => (
+            <div key={i} className="flex gap-2 items-center">
+              <TextField
+                size="small"
+                label="Key"
+                value={row.key}
+                onChange={(e) => updateRow(i, "key", e.target.value)}
+                sx={{
+                  flex: 1,
+                  "& .MuiInputBase-root": { bgcolor: "#1f2937", color: "#fff" },
+                  "& .MuiInputLabel-root": { color: "#9ca3af" },
+                  "& .MuiOutlinedInput-notchedOutline": { borderColor: "#374151" },
+                }}
+              />
+              <TextField
+                size="small"
+                label="Value"
+                value={row.value}
+                onChange={(e) => updateRow(i, "value", e.target.value)}
+                sx={{
+                  flex: 1,
+                  "& .MuiInputBase-root": { bgcolor: "#1f2937", color: "#fff" },
+                  "& .MuiInputLabel-root": { color: "#9ca3af" },
+                  "& .MuiOutlinedInput-notchedOutline": { borderColor: "#374151" },
+                }}
+              />
+              <IconButton
+                onClick={() => removeRow(i)}
+                size="small"
+                sx={{ color: "#ef4444" }}
+                aria-label="Remove tag"
+              >
+                ×
+              </IconButton>
+            </div>
+          ))}
+        </div>
+        <Button
+          onClick={addRow}
+          size="small"
+          sx={{ mt: 2, color: "#60a5fa", textTransform: "none" }}
+        >
+          + Add tag
+        </Button>
+      </DialogContent>
+      <DialogActions sx={{ borderTop: "1px solid #374151", px: 3, py: 2 }}>
+        <Button
+          onClick={onClose}
+          sx={{ color: "#9ca3af", textTransform: "none" }}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSave}
+          disabled={saving}
+          variant="contained"
+          sx={{
+            bgcolor: "#2563eb",
+            "&:hover": { bgcolor: "#1d4ed8" },
+            "&.Mui-disabled": { bgcolor: "#374151", color: "#6b7280" },
+            textTransform: "none",
+          }}
+        >
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/lib/api/schema.d.ts
+++ b/src/lib/api/schema.d.ts
@@ -256,6 +256,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/hdts/{id}/properties/{propertyId}/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Replace Property tags
+         * @description Replaces the entire tag map of a single Property spec. The request body is the complete desired tag map; an empty object clears all tags.
+         */
+        put: operations["properties/{propertyId}/tags/put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/observations/batch": {
         parameters: {
             query?: never;
@@ -1495,6 +1515,58 @@ export interface operations {
                 content?: never;
             };
             /** @description Failed to upsert property specs */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "properties/{propertyId}/tags/put": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                propertyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Tags replaced; returns the new tag map */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
+                    };
+                };
+            };
+            /** @description Missing path parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Property not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to update tags */
             500: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Closes #28

## Summary

- New `src/components/PropertyTagEditor.tsx`: MUI Dialog for viewing and editing a property's tags as key–value rows with add/remove/inline-edit, client-side validation (empty keys, duplicates), and PUT to `/hdts/{id}/properties/{propertyId}/tags` via the typed openapi-fetch client
- `HdtDetail.tsx`: `tags` field added to `DisplayRow`, populated from `prop.tags ?? {}`, Tags column with per-row trigger button (`e.stopPropagation()`), `editorTarget` state, `PropertyTagEditor` wired to `fetchSpec()` on save
- `schema.d.ts` regenerated from `openapi.yaml` via `npm run gen:api:local` (not hand-edited)

## Manual smoke test

- [ ] Opening editor from a row does not navigate to property-live
- [ ] Save updates the row's tag count
- [ ] Empty keys are blocked with a message
- [ ] Duplicate keys are blocked with a message

Generated with [Claude Code](https://claude.ai/code)