### PR TITLE
feat: Add per-task HDT status view (HdtTaskView) wrapping HdtDetail

### DIFF
--- a/src/components/HdtDetail.tsx
+++ b/src/components/HdtDetail.tsx
@@ -9,8 +9,11 @@ import { HdtSpecResponse, PropertySnapshotEntry, PropertyValue } from "@/lib/api
 import { api } from "@/lib/api/client";
 import PropertyTagEditor from "./PropertyTagEditor";
 
+export const NO_TASK = "__no_task__";
+
 interface HdtDetailProps {
   id: string;
+  task?: string;
 }
 
 type DisplayRow = {
@@ -22,7 +25,7 @@ type DisplayRow = {
   tags: Record<string, string>;
 };
 
-export default function HdtDetail({ id }: HdtDetailProps) {
+export default function HdtDetail({ id, task }: HdtDetailProps) {
   const [spec, setSpec] = useState<HdtSpecResponse | null>(null);
   const [snapshot, setSnapshot] = useState<PropertySnapshotEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -94,8 +97,23 @@ export default function HdtDetail({ id }: HdtDetailProps) {
     );
   }, [spec, snapshot]);
 
+  const taskScopedRows = useMemo(() => {
+    if (task === undefined) return displayRows;
+    if (task === NO_TASK) return displayRows.filter((r) => !("task" in r.tags));
+    return displayRows.filter((r) => r.tags.task === task);
+  }, [displayRows, task]);
+
+  const modelNamesInScope = useMemo(
+    () => Array.from(new Set(taskScopedRows.map((r) => r.modelName))),
+    [taskScopedRows]
+  );
+
+  useEffect(() => {
+    setSelectedModelName("All");
+  }, [task]);
+
   const filteredRows = useMemo(() => {
-    return displayRows.filter((row) => {
+    return taskScopedRows.filter((row) => {
       const matchesModel =
         selectedModelName === "All" || row.modelName === selectedModelName;
 
@@ -111,7 +129,7 @@ export default function HdtDetail({ id }: HdtDetailProps) {
         return true;
       }
     });
-  }, [displayRows, selectedModelName, search]);
+  }, [taskScopedRows, selectedModelName, search]);
 
   return (
     <div className="bg-gray-900 text-white p-4 rounded shadow w-full">
@@ -150,8 +168,8 @@ export default function HdtDetail({ id }: HdtDetailProps) {
               }}
             >
               <Tab value="All" label="All" />
-              {spec?.models.map((m) => (
-                <Tab key={m.modelId} value={m.modelName} label={m.modelName} />
+              {modelNamesInScope.map((name) => (
+                <Tab key={name} value={name} label={name} />
               ))}
             </Tabs>
           </div>

--- a/src/components/HdtManager.tsx
+++ b/src/components/HdtManager.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import HdtDetail from "@/components/HdtDetail";
+import HdtTaskView from "@/components/HdtTaskView";
 import { api } from "@/lib/api/client";
 import { HumanDigitalTwinDocument } from "@/lib/api/schema";
 
@@ -225,7 +225,7 @@ export default function HdtManager() {
 
         {/* HDT Details */}
         <div className="flex-1 min-w-0">
-          {highlightedDT && <HdtDetail id={highlightedDT.hdtId} />}
+          {highlightedDT && <HdtTaskView id={highlightedDT.hdtId} />}
         </div>
       </div>
     </div>

--- a/src/components/HdtTaskView.tsx
+++ b/src/components/HdtTaskView.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import { HdtSpecResponse } from "@/lib/api/schema";
+import { api } from "@/lib/api/client";
+import HdtDetail, { NO_TASK } from "./HdtDetail";
+
+interface HdtTaskViewProps {
+  id: string;
+}
+
+export default function HdtTaskView({ id }: HdtTaskViewProps) {
+  const [spec, setSpec] = useState<HdtSpecResponse | null>(null);
+  const [activeTask, setActiveTask] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await api.GET("/hdts/{id}/spec", { params: { path: { id } } });
+        if (!cancelled) setSpec(res.data ?? null);
+      } catch (err) {
+        console.error("Failed to fetch HDT spec for task view:", err);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [id]);
+
+  const { tasks, hasUntagged } = useMemo(() => {
+    if (!spec) return { tasks: [] as string[], hasUntagged: false };
+    const set = new Set<string>();
+    let untagged = false;
+    for (const model of spec.models) {
+      for (const prop of model.properties) {
+        const tags = prop.tags;
+        if (tags && "task" in tags) set.add(tags.task);
+        else untagged = true;
+      }
+    }
+    return { tasks: Array.from(set).sort(), hasUntagged: untagged };
+  }, [spec]);
+
+  useEffect(() => {
+    if (!spec) return;
+    setActiveTask((prev) => {
+      if (prev !== undefined) return prev;
+      if (tasks.length > 0) return tasks[0];
+      if (hasUntagged) return NO_TASK;
+      return undefined;
+    });
+  }, [spec, tasks, hasUntagged]);
+
+  if (spec === null) return <p className="text-white p-4">Loading...</p>;
+
+  if (tasks.length === 0 && !hasUntagged) {
+    return <HdtDetail id={id} />;
+  }
+
+  return (
+    <div className="w-full">
+      <div className="w-full overflow-hidden">
+        <Tabs
+          value={activeTask ?? false}
+          onChange={(_, v) => setActiveTask(v)}
+          variant="scrollable"
+          scrollButtons="auto"
+          allowScrollButtonsMobile
+          sx={{
+            maxWidth: "100%",
+            minHeight: 40,
+            "& .MuiTabs-scroller": {
+              overflowX: "auto !important",
+            },
+            "& .MuiTab-root": {
+              color: "#d1d5db",
+              textTransform: "none",
+              minHeight: 40,
+            },
+            "& .Mui-selected": {
+              color: "#fff",
+            },
+            "& .MuiTabs-indicator": {
+              backgroundColor: "#60a5fa",
+            },
+            "& .MuiTabs-scrollButtons": {
+              color: "#d1d5db",
+            },
+          }}
+        >
+          {tasks.map((t) => <Tab key={t} value={t} label={t} />)}
+          {hasUntagged && <Tab value={NO_TASK} label="Untagged" />}
+        </Tabs>
+      </div>
+      {activeTask !== undefined && <HdtDetail id={id} task={activeTask} />}
+    </div>
+  );
+}


### PR DESCRIPTION
Implements #issue-32

## Files modified
- `src/components/HdtDetail.tsx` — additive: `NO_TASK` sentinel export, `task?: string` prop, task-scoped row filtering, task-aware model tabs, reset effect
- `src/components/HdtTaskView.tsx` — new component
- `src/components/HdtManager.tsx` — one-line mount swap

## Design decisions
- Task-aware inner model tabs: `modelNamesInScope` derived from `taskScopedRows` so only models present in the active task appear
- Conditional `Untagged` tab: appears only when ≥1 property has no `task` key in its tags (detected via `"task" in tags`)
- Legacy fallback: HDTs with no task-tagged or untagged properties fall back to unscoped `HdtDetail`
- Single persistent `HdtDetail` with changing `task` prop (no remount on tab switch)
- Second `/spec` fetch accepted as deliberate tradeoff per spec (deduplication deferred)

Generated with [Claude Code](https://claude.ai/code)