### PR TITLE
refactor: lift /spec ownership to HdtTaskView, collapse single-model tabs

### DIFF
--- a/src/components/HdtDetail.tsx
+++ b/src/components/HdtDetail.tsx
@@ -13,7 +13,9 @@ export const NO_TASK = "__no_task__";
 
 interface HdtDetailProps {
   id: string;
+  spec: HdtSpecResponse;
   task?: string;
+  onTagSaved?: () => void;
 }
 
 type DisplayRow = {
@@ -25,37 +27,14 @@ type DisplayRow = {
   tags: Record<string, string>;
 };
 
-export default function HdtDetail({ id, task }: HdtDetailProps) {
-  const [spec, setSpec] = useState<HdtSpecResponse | null>(null);
+export default function HdtDetail({ id, spec, task, onTagSaved }: HdtDetailProps) {
   const [snapshot, setSnapshot] = useState<PropertySnapshotEntry[]>([]);
-  const [loading, setLoading] = useState(true);
   const router = useRouter();
   const [search, setSearch] = useState("");
   const [selectedModelName, setSelectedModelName] = useState<string>("All");
   const [editorTarget, setEditorTarget] = useState<DisplayRow | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-
-  const fetchSpec = async () => {
-    try {
-      const res = await api.GET("/hdts/{id}/spec", {
-        params: {
-          path: { id }
-        }
-      });
-      const data = res.data;
-      if (data) {
-        setSpec(data);
-        setSelectedModelName((prev) =>
-          prev === "All" || data.models.some((m) => m.modelName === prev) ? prev : "All"
-        );
-      }
-    } catch (err) {
-      console.error("Failed to fetch HDT spec:", err);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const fetchSnapshot = async () => {
     try {
@@ -81,13 +60,11 @@ export default function HdtDetail({ id, task }: HdtDetailProps) {
   };
 
   useEffect(() => {
-    fetchSpec();
     refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 
   const displayRows: DisplayRow[] = useMemo(() => {
-    if (!spec) return [];
     const snapshotMap = new Map(snapshot.map((s) => [s.propertyId, s]));
     return spec.models.flatMap((model) =>
       model.properties.map((prop) => {
@@ -119,10 +96,12 @@ export default function HdtDetail({ id, task }: HdtDetailProps) {
     setSelectedModelName("All");
   }, [task]);
 
+  const effectiveModel =
+    modelNamesInScope.includes(selectedModelName) ? selectedModelName : "All";
+
   const filteredRows = useMemo(() => {
     return taskScopedRows.filter((row) => {
-      const matchesModel =
-        selectedModelName === "All" || row.modelName === selectedModelName;
+      const matchesModel = effectiveModel === "All" || row.modelName === effectiveModel;
 
       if (!matchesModel) return false;
 
@@ -136,7 +115,7 @@ export default function HdtDetail({ id, task }: HdtDetailProps) {
         return true;
       }
     });
-  }, [taskScopedRows, selectedModelName, search]);
+  }, [taskScopedRows, effectiveModel, search]);
 
   return (
     <div className="bg-gray-900 text-white p-4 rounded shadow w-full">
@@ -155,106 +134,103 @@ export default function HdtDetail({ id, task }: HdtDetailProps) {
           </button>
         </div>
       </div>
-      {loading ? (
-        <p>Loading...</p>
-      ) : (
-        <>
-          <div className="w-full overflow-hidden">
-            <Tabs
-              value={selectedModelName}
-              onChange={(_, newValue) => setSelectedModelName(newValue)}
-              variant="scrollable"
-              scrollButtons="auto"
-              allowScrollButtonsMobile
-              sx={{
-                maxWidth: "100%",
+
+      {modelNamesInScope.length > 1 && (
+        <div className="w-full overflow-hidden">
+          <Tabs
+            value={effectiveModel}
+            onChange={(_, newValue) => setSelectedModelName(newValue)}
+            variant="scrollable"
+            scrollButtons="auto"
+            allowScrollButtonsMobile
+            sx={{
+              maxWidth: "100%",
+              minHeight: 40,
+              "& .MuiTabs-scroller": {
+                overflowX: "auto !important",
+              },
+              "& .MuiTab-root": {
+                color: "#d1d5db",
+                textTransform: "none",
                 minHeight: 40,
-                "& .MuiTabs-scroller": {
-                  overflowX: "auto !important",
-                },
-                "& .MuiTab-root": {
-                  color: "#d1d5db",
-                  textTransform: "none",
-                  minHeight: 40,
-                },
-                "& .Mui-selected": {
-                  color: "#fff",
-                },
-                "& .MuiTabs-indicator": {
-                  backgroundColor: "#60a5fa",
-                },
-                "& .MuiTabs-scrollButtons": {
-                  color: "#d1d5db",
-                },
-              }}
-            >
-              <Tab value="All" label="All" />
-              {modelNamesInScope.map((name) => (
-                <Tab key={name} value={name} label={name} />
-              ))}
-            </Tabs>
-          </div>
+              },
+              "& .Mui-selected": {
+                color: "#fff",
+              },
+              "& .MuiTabs-indicator": {
+                backgroundColor: "#60a5fa",
+              },
+              "& .MuiTabs-scrollButtons": {
+                color: "#d1d5db",
+              },
+            }}
+          >
+            <Tab value="All" label="All" />
+            {modelNamesInScope.map((name) => (
+              <Tab key={name} value={name} label={name} />
+            ))}
+          </Tabs>
+        </div>
+      )}
 
-          <Filter
-            value={search}
-            onChange={setSearch}
-            placeholder="Search property..."
-            className="mb-4 p-2 border border-gray-700 rounded bg-gray-900 text-white w-full"
-          />
+      <Filter
+        value={search}
+        onChange={setSearch}
+        placeholder="Search property..."
+        className="mb-4 p-2 border border-gray-700 rounded bg-gray-900 text-white w-full"
+      />
 
-          <div className="w-full overflow-x-auto">
-            <table className="min-w-full text-sm text-left border border-gray-600 mt-2 text-white">
-              <thead className="bg-gray-800 text-gray-300">
-                <tr>
-                  <th className="p-2 border border-gray-600">Model</th>
-                  <th className="p-2 border border-gray-600">Property</th>
-                  <th className="p-2 border border-gray-600">Value</th>
-                  <th className="p-2 border border-gray-600">Timestamp</th>
-                  <th className="p-2 border border-gray-600">Tags</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredRows.map((row) => (
-                  <tr
-                    key={row.propertyId}
-                    className="bg-gray-900 hover:bg-gray-800"
-                    onClick={() => router.push(`/hdt/${id}/property-live`)}
+      <div className="w-full overflow-x-auto">
+        <table className="min-w-full text-sm text-left border border-gray-600 mt-2 text-white">
+          <thead className="bg-gray-800 text-gray-300">
+            <tr>
+              <th className="p-2 border border-gray-600">Model</th>
+              <th className="p-2 border border-gray-600">Property</th>
+              <th className="p-2 border border-gray-600">Value</th>
+              <th className="p-2 border border-gray-600">Timestamp</th>
+              <th className="p-2 border border-gray-600">Tags</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredRows.map((row) => (
+              <tr
+                key={row.propertyId}
+                className="bg-gray-900 hover:bg-gray-800"
+                onClick={() => router.push(`/hdt/${id}/property-live`)}
+              >
+                <td className="p-2 border border-gray-700">{row.modelName}</td>
+                <td className="p-2 border border-gray-700">{row.propertyName}</td>
+                <td className="p-2 border border-gray-700">
+                  {row.value != null
+                    ? String((row.value as { value?: unknown }).value ?? "—")
+                    : "—"}
+                </td>
+                <td className="p-2 border border-gray-700">
+                  {row.timestamp ? new Date(row.timestamp).toDateString() : "—"}
+                </td>
+                <td className="p-2 border border-gray-700">
+                  <button
+                    className="px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 text-xs"
+                    onClick={(e) => { e.stopPropagation(); setEditorTarget(row); }}
                   >
-                    <td className="p-2 border border-gray-700">{row.modelName}</td>
-                    <td className="p-2 border border-gray-700">{row.propertyName}</td>
-                    <td className="p-2 border border-gray-700">
-                      {row.value != null
-                        ? String((row.value as { value?: unknown }).value ?? "—")
-                        : "—"}
-                    </td>
-                    <td className="p-2 border border-gray-700">
-                      {row.timestamp ? new Date(row.timestamp).toDateString() : "—"}
-                    </td>
-                    <td className="p-2 border border-gray-700">
-                      <button
-                        className="px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 text-xs"
-                        onClick={(e) => { e.stopPropagation(); setEditorTarget(row); }}
-                      >
-                        🏷 {Object.keys(row.tags).length}
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          {editorTarget && (
-            <PropertyTagEditor
-              open={!!editorTarget}
-              hdtId={id}
-              propertyId={editorTarget.propertyId}
-              propertyName={editorTarget.propertyName}
-              initialTags={editorTarget.tags}
-              onClose={() => setEditorTarget(null)}
-              onSaved={() => { fetchSpec(); setEditorTarget(null); }}
-            />
-          )}
-        </>
+                    🏷 {Object.keys(row.tags).length}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {editorTarget && (
+        <PropertyTagEditor
+          open={!!editorTarget}
+          hdtId={id}
+          propertyId={editorTarget.propertyId}
+          propertyName={editorTarget.propertyName}
+          initialTags={editorTarget.tags}
+          onClose={() => setEditorTarget(null)}
+          onSaved={() => { onTagSaved?.(); setEditorTarget(null); }}
+        />
       )}
     </div>
   );

--- a/src/components/HdtTaskView.tsx
+++ b/src/components/HdtTaskView.tsx
@@ -15,17 +15,18 @@ export default function HdtTaskView({ id }: HdtTaskViewProps) {
   const [spec, setSpec] = useState<HdtSpecResponse | null>(null);
   const [activeTask, setActiveTask] = useState<string | undefined>(undefined);
 
+  const fetchSpec = async () => {
+    try {
+      const res = await api.GET("/hdts/{id}/spec", { params: { path: { id } } });
+      setSpec(res.data ?? null);
+    } catch (err) {
+      console.error("Failed to fetch HDT spec for task view:", err);
+    }
+  };
+
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await api.GET("/hdts/{id}/spec", { params: { path: { id } } });
-        if (!cancelled) setSpec(res.data ?? null);
-      } catch (err) {
-        console.error("Failed to fetch HDT spec for task view:", err);
-      }
-    })();
-    return () => { cancelled = true; };
+    fetchSpec();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 
   const { tasks, hasUntagged } = useMemo(() => {
@@ -45,7 +46,10 @@ export default function HdtTaskView({ id }: HdtTaskViewProps) {
   useEffect(() => {
     if (!spec) return;
     setActiveTask((prev) => {
-      if (prev !== undefined) return prev;
+      const stillValid =
+        (prev !== undefined && prev !== NO_TASK && tasks.includes(prev)) ||
+        (prev === NO_TASK && hasUntagged);
+      if (stillValid) return prev;
       if (tasks.length > 0) return tasks[0];
       if (hasUntagged) return NO_TASK;
       return undefined;
@@ -55,7 +59,7 @@ export default function HdtTaskView({ id }: HdtTaskViewProps) {
   if (spec === null) return <p className="text-white p-4">Loading...</p>;
 
   if (tasks.length === 0 && !hasUntagged) {
-    return <HdtDetail id={id} />;
+    return <HdtDetail id={id} spec={spec} onTagSaved={fetchSpec} />;
   }
 
   return (
@@ -93,7 +97,9 @@ export default function HdtTaskView({ id }: HdtTaskViewProps) {
           {hasUntagged && <Tab value={NO_TASK} label="Untagged" />}
         </Tabs>
       </div>
-      {activeTask !== undefined && <HdtDetail id={id} task={activeTask} />}
+      {activeTask !== undefined && (
+        <HdtDetail id={id} task={activeTask} spec={spec} onTagSaved={fetchSpec} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #36

## Files modified
- `src/components/HdtTaskView.tsx`
- `src/components/HdtDetail.tsx`

## Summary
- `HdtTaskView` is now the single owner of `GET /hdts/{id}/spec`; passes `spec` and `onTagSaved={fetchSpec}` to every `<HdtDetail>` it renders
- `HdtDetail` is now presentational w.r.t. the spec: `spec` state, `loading` state, and `fetchSpec` removed; `displayRows` derives from the `spec` prop
- `effectiveModel` self-corrects a stale `selectedModelName` after task/spec change
- Model-tab row collapsed when `modelNamesInScope.length <= 1`
- Active-task effect validates instead of blindly defaulting
- Snapshot fetching and Refresh button deliberately untouched

Generated with [Claude Code](https://claude.ai/code)