### PR TITLE
refactor: drive HdtTaskView from by-task snapshot; make HdtDetail presentational

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -180,6 +180,31 @@ paths:
           description: Missing HDT id
         '500':
           description: HDT or associated data not found
+  /hdts/{id}/snapshot/by-task:
+    get:
+      operationId: hdts/snapshot/by-task
+      summary: By-task property snapshot
+      description: >-
+        Latest observed value per (property, task) for the specified HDT. A property
+        appears under each task in which it was observed. 'task' is null for
+        observations recorded without a task.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: By-task snapshot entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TaskPropertySnapshotEntry'
+        '400':
+          description: Missing HDT id
   /hdts/{id}/snapshot:
     get:
       operationId: hdts/{id}/snapshot
@@ -1397,6 +1422,31 @@ components:
           enum:
           - observation
           - initial_value
+    TaskPropertySnapshotEntry:
+      type: object
+      title: io.github.whdt.db.assembler.TaskPropertySnapshotEntry
+      required:
+      - propertyId
+      - propertyName
+      - modelName
+      - value
+      - timestamp
+      properties:
+        task:
+          type:
+          - string
+          - 'null'
+        propertyId:
+          type: string
+        propertyName:
+          type: string
+        modelName:
+          type: string
+        value:
+          $ref: '#/components/schemas/PropertyValue'
+        timestamp:
+          type: string
+          format: date-time
     PropertyValuesRequest:
       type: object
       title: io.github.whdt.routing.query.event.values.PropertyValuesRequest

--- a/src/components/HdtDetail.tsx
+++ b/src/components/HdtDetail.tsx
@@ -1,20 +1,17 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Filter } from "./Filter";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
-import { HdtSpecResponse, PropertySnapshotEntry, PropertyValue } from "@/lib/api/schema";
-import { api } from "@/lib/api/client";
+import { HdtSpecResponse, PropertySpecEntry, PropertyValue, TaskPropertySnapshotEntry } from "@/lib/api/schema";
 import PropertyTagEditor from "./PropertyTagEditor";
-
-export const NO_TASK = "__no_task__";
 
 interface HdtDetailProps {
   id: string;
+  entries: TaskPropertySnapshotEntry[];
   spec: HdtSpecResponse;
-  task?: string;
   onTagSaved?: () => void;
 }
 
@@ -22,117 +19,66 @@ type DisplayRow = {
   modelName: string;
   propertyId: string;
   propertyName: string;
-  value: PropertyValue | null | undefined;
-  timestamp: string | null | undefined;
+  value: PropertyValue;
+  timestamp: string;
   tags: Record<string, string>;
+  declaredType?: string;
 };
 
-export default function HdtDetail({ id, spec, task, onTagSaved }: HdtDetailProps) {
-  const [snapshot, setSnapshot] = useState<PropertySnapshotEntry[]>([]);
+export default function HdtDetail({ id, entries, spec, onTagSaved }: HdtDetailProps) {
   const router = useRouter();
   const [search, setSearch] = useState("");
   const [selectedModelName, setSelectedModelName] = useState<string>("All");
   const [editorTarget, setEditorTarget] = useState<DisplayRow | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
-  const fetchSnapshot = async () => {
-    try {
-      const res = await api.GET("/hdts/{id}/snapshot", {
-        params: {
-          path: { id }
-        }
-      });
-      setSnapshot(res.data ?? []);
-    } catch (err) {
-      console.error("Failed to fetch HDT snapshot:", err);
+  const specByPropertyId = useMemo(() => {
+    const m = new Map<string, PropertySpecEntry>();
+    for (const model of spec.models) {
+      for (const p of model.properties) m.set(p.propertyId, p);
     }
-  };
-
-  const refresh = async () => {
-    setRefreshing(true);
-    try {
-      await fetchSnapshot();
-      setLastUpdated(new Date());
-    } finally {
-      setRefreshing(false);
-    }
-  };
-
-  useEffect(() => {
-    refresh();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
+    return m;
+  }, [spec]);
 
   const displayRows: DisplayRow[] = useMemo(() => {
-    const snapshotMap = new Map(snapshot.map((s) => [s.propertyId, s]));
-    return spec.models.flatMap((model) =>
-      model.properties.map((prop) => {
-        const obs = snapshotMap.get(prop.propertyId);
-        return {
-          modelName: model.modelName,
-          propertyId: prop.propertyId,
-          propertyName: prop.propertyName,
-          value: obs?.value ?? prop.initialValue,
-          timestamp: obs?.timestamp ?? null,
-          tags: prop.tags ?? {},
-        };
-      })
-    );
-  }, [spec, snapshot]);
-
-  const taskScopedRows = useMemo(() => {
-    if (task === undefined) return displayRows;
-    if (task === NO_TASK) return displayRows.filter((r) => !("task" in r.tags));
-    return displayRows.filter((r) => r.tags.task === task);
-  }, [displayRows, task]);
+    return entries.map((e) => {
+      const sp = specByPropertyId.get(e.propertyId);
+      return {
+        modelName: e.modelName,
+        propertyId: e.propertyId,
+        propertyName: e.propertyName,
+        value: e.value,
+        timestamp: e.timestamp,
+        tags: sp?.tags ?? {},
+        declaredType: sp?.declaredType,
+      };
+    });
+  }, [entries, specByPropertyId]);
 
   const modelNamesInScope = useMemo(
-    () => Array.from(new Set(taskScopedRows.map((r) => r.modelName))),
-    [taskScopedRows]
+    () => Array.from(new Set(displayRows.map((r) => r.modelName))),
+    [displayRows]
   );
 
-  useEffect(() => {
-    setSelectedModelName("All");
-  }, [task]);
-
-  const effectiveModel =
-    modelNamesInScope.includes(selectedModelName) ? selectedModelName : "All";
+  const effectiveModel = modelNamesInScope.includes(selectedModelName) ? selectedModelName : "All";
 
   const filteredRows = useMemo(() => {
-    return taskScopedRows.filter((row) => {
+    return displayRows.filter((row) => {
       const matchesModel = effectiveModel === "All" || row.modelName === effectiveModel;
-
       if (!matchesModel) return false;
-
       const q = search.trim();
       if (!q) return true;
-
       try {
-        const regex = new RegExp(q, "i");
-        return regex.test(row.propertyName);
+        return new RegExp(q, "i").test(row.propertyName);
       } catch {
         return true;
       }
     });
-  }, [taskScopedRows, effectiveModel, search]);
+  }, [displayRows, effectiveModel, search]);
 
   return (
     <div className="bg-gray-900 text-white p-4 rounded shadow w-full">
       <div className="flex items-center justify-between mb-2">
         <h2 className="font-bold text-lg">State of {id}</h2>
-        <div className="flex items-center gap-2">
-          {lastUpdated && (
-            <span className="text-xs text-gray-400">Updated {lastUpdated.toLocaleTimeString()}</span>
-          )}
-          <button
-            onClick={refresh}
-            disabled={refreshing}
-            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 text-sm disabled:opacity-50"
-          >
-            {refreshing ? "Refreshing…" : "↻ Refresh"}
-          </button>
-        </div>
       </div>
 
       {modelNamesInScope.length > 1 && (

--- a/src/components/HdtTaskView.tsx
+++ b/src/components/HdtTaskView.tsx
@@ -3,102 +3,133 @@
 import { useEffect, useMemo, useState } from "react";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
-import { HdtSpecResponse } from "@/lib/api/schema";
+import { HdtSpecResponse, TaskPropertySnapshotEntry } from "@/lib/api/schema";
 import { api } from "@/lib/api/client";
-import HdtDetail, { NO_TASK } from "./HdtDetail";
+import HdtDetail from "./HdtDetail";
+
+export const NO_TASK = "__no_task__";
 
 interface HdtTaskViewProps {
   id: string;
 }
 
+const taskKeyOf = (t: string | null | undefined) => (t == null ? NO_TASK : t);
+
 export default function HdtTaskView({ id }: HdtTaskViewProps) {
   const [spec, setSpec] = useState<HdtSpecResponse | null>(null);
+  const [byTask, setByTask] = useState<TaskPropertySnapshotEntry[]>([]);
   const [activeTask, setActiveTask] = useState<string | undefined>(undefined);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
   const fetchSpec = async () => {
     try {
       const res = await api.GET("/hdts/{id}/spec", { params: { path: { id } } });
       setSpec(res.data ?? null);
     } catch (err) {
-      console.error("Failed to fetch HDT spec for task view:", err);
+      console.error("Failed to fetch HDT spec:", err);
+    }
+  };
+
+  const fetchByTask = async () => {
+    try {
+      const res = await api.GET("/hdts/{id}/snapshot/by-task", { params: { path: { id } } });
+      setByTask(res.data ?? []);
+    } catch (err) {
+      console.error("Failed to fetch by-task snapshot:", err);
+    }
+  };
+
+  const refresh = async () => {
+    setRefreshing(true);
+    try {
+      await fetchByTask();
+      setLastUpdated(new Date());
+    } finally {
+      setRefreshing(false);
     }
   };
 
   useEffect(() => {
     fetchSpec();
+    refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 
-  const { tasks, hasUntagged } = useMemo(() => {
-    if (!spec) return { tasks: [] as string[], hasUntagged: false };
+  const tasks = useMemo(() => {
     const set = new Set<string>();
-    let untagged = false;
-    for (const model of spec.models) {
-      for (const prop of model.properties) {
-        const tags = prop.tags;
-        if (tags && "task" in tags) set.add(tags.task);
-        else untagged = true;
-      }
-    }
-    return { tasks: Array.from(set).sort(), hasUntagged: untagged };
-  }, [spec]);
+    for (const e of byTask) set.add(taskKeyOf(e.task));
+    const real = Array.from(set).filter((t) => t !== NO_TASK).sort();
+    return set.has(NO_TASK) ? [...real, NO_TASK] : real;
+  }, [byTask]);
 
   useEffect(() => {
-    if (!spec) return;
-    setActiveTask((prev) => {
-      const stillValid =
-        (prev !== undefined && prev !== NO_TASK && tasks.includes(prev)) ||
-        (prev === NO_TASK && hasUntagged);
-      if (stillValid) return prev;
-      if (tasks.length > 0) return tasks[0];
-      if (hasUntagged) return NO_TASK;
-      return undefined;
-    });
-  }, [spec, tasks, hasUntagged]);
+    setActiveTask((prev) => (prev !== undefined && tasks.includes(prev) ? prev : tasks[0]));
+  }, [tasks]);
+
+  const activeEntries = useMemo(
+    () => (activeTask === undefined ? [] : byTask.filter((e) => taskKeyOf(e.task) === activeTask)),
+    [byTask, activeTask]
+  );
 
   if (spec === null) return <p className="text-white p-4">Loading...</p>;
 
-  if (tasks.length === 0 && !hasUntagged) {
-    return <HdtDetail id={id} spec={spec} onTagSaved={fetchSpec} />;
-  }
-
   return (
     <div className="w-full">
-      <div className="w-full overflow-hidden">
-        <Tabs
-          value={activeTask ?? false}
-          onChange={(_, v) => setActiveTask(v)}
-          variant="scrollable"
-          scrollButtons="auto"
-          allowScrollButtonsMobile
-          sx={{
-            maxWidth: "100%",
-            minHeight: 40,
-            "& .MuiTabs-scroller": {
-              overflowX: "auto !important",
-            },
-            "& .MuiTab-root": {
-              color: "#d1d5db",
-              textTransform: "none",
-              minHeight: 40,
-            },
-            "& .Mui-selected": {
-              color: "#fff",
-            },
-            "& .MuiTabs-indicator": {
-              backgroundColor: "#60a5fa",
-            },
-            "& .MuiTabs-scrollButtons": {
-              color: "#d1d5db",
-            },
-          }}
-        >
-          {tasks.map((t) => <Tab key={t} value={t} label={t} />)}
-          {hasUntagged && <Tab value={NO_TASK} label="Untagged" />}
-        </Tabs>
+      <div className="flex items-center justify-between mb-2 gap-2">
+        <div className="overflow-hidden">
+          {tasks.length > 0 ? (
+            <Tabs
+              value={activeTask ?? false}
+              onChange={(_, v) => setActiveTask(v)}
+              variant="scrollable"
+              scrollButtons="auto"
+              allowScrollButtonsMobile
+              sx={{
+                maxWidth: "100%",
+                minHeight: 40,
+                "& .MuiTabs-scroller": {
+                  overflowX: "auto !important",
+                },
+                "& .MuiTab-root": {
+                  color: "#d1d5db",
+                  textTransform: "none",
+                  minHeight: 40,
+                },
+                "& .Mui-selected": {
+                  color: "#fff",
+                },
+                "& .MuiTabs-indicator": {
+                  backgroundColor: "#60a5fa",
+                },
+                "& .MuiTabs-scrollButtons": {
+                  color: "#d1d5db",
+                },
+              }}
+            >
+              {tasks.map((t) => (
+                <Tab key={t} value={t} label={t === NO_TASK ? "Untagged" : t} />
+              ))}
+            </Tabs>
+          ) : (
+            <p className="text-gray-400">No observations recorded for this HDT yet.</p>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {lastUpdated && (
+            <span className="text-xs text-gray-400">Updated {lastUpdated.toLocaleTimeString()}</span>
+          )}
+          <button
+            onClick={refresh}
+            disabled={refreshing}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 text-sm disabled:opacity-50"
+          >
+            {refreshing ? "Refreshing…" : "↻ Refresh"}
+          </button>
+        </div>
       </div>
       {activeTask !== undefined && (
-        <HdtDetail id={id} task={activeTask} spec={spec} onTagSaved={fetchSpec} />
+        <HdtDetail id={id} entries={activeEntries} spec={spec} onTagSaved={fetchSpec} />
       )}
     </div>
   );

--- a/src/lib/api/schema.d.ts
+++ b/src/lib/api/schema.d.ts
@@ -120,6 +120,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/hdts/{id}/snapshot/by-task": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * By-task property snapshot
+         * @description Latest observed value per (property, task) for the specified HDT. A property appears under each task in which it was observed. 'task' is null for observations recorded without a task.
+         */
+        get: operations["hdts/snapshot/by-task"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/hdts/{id}/snapshot": {
         parameters: {
             query?: never;
@@ -803,6 +823,16 @@ export interface components {
             /** @enum {string} */
             source: "observation" | "initial_value";
         };
+        /** io.github.whdt.db.assembler.TaskPropertySnapshotEntry */
+        TaskPropertySnapshotEntry: {
+            task?: string | null;
+            propertyId: string;
+            propertyName: string;
+            modelName: string;
+            value: components["schemas"]["PropertyValue"];
+            /** Format: date-time */
+            timestamp: string;
+        };
         /** io.github.whdt.routing.query.event.values.PropertyValuesRequest */
         PropertyValuesRequest: {
             hdtId?: string;
@@ -955,6 +985,7 @@ export type PropertySpecEntry = components['schemas']['PropertySpecEntry'];
 export type ModelSpecEntry = components['schemas']['ModelSpecEntry'];
 export type HdtSpecResponse = components['schemas']['HdtSpecResponse'];
 export type PropertySnapshotEntry = components['schemas']['PropertySnapshotEntry'];
+export type TaskPropertySnapshotEntry = components['schemas']['TaskPropertySnapshotEntry'];
 export type PropertyValuesRequest = components['schemas']['PropertyValuesRequest'];
 export type PropertyStatsRequest = components['schemas']['PropertyStatsRequest'];
 export type PropertyStatsPerHdt = components['schemas']['PropertyStatsPerHdt'];
@@ -1217,6 +1248,35 @@ export interface operations {
             };
             /** @description HDT or associated data not found */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "hdts/snapshot/by-task": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description By-task snapshot entries */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskPropertySnapshotEntry"][];
+                };
+            };
+            /** @description Missing HDT id */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Closes #38

## Files modified

- `src/components/HdtTaskView.tsx`
- `src/components/HdtDetail.tsx`
- `src/lib/api/schema.d.ts`
- `openapi.yaml`

## Design decisions

**Tabs + per-task values are now observation-driven via the by-task snapshot.** Previously, tabs were derived from `prop.tags.task` in the spec, which collapsed to the last task when a property was shared across tasks. Now they come from the distinct `task` values in the GET `/hdts/{id}/snapshot/by-task` response, so each task gets its own correct values.

**HdtTaskView is the sole data owner with panel-level Refresh.** It fetches both the by-task snapshot (tabs + values) and the spec (tag/declaredType decoration). Refresh re-fetches the snapshot only; the spec is re-fetched after a tag save. No polling introduced.

**HdtDetail is fully presentational.** Removed all fetching, polling, refreshing state, the Refresh button, and task-tag filtering. It accepts `entries: TaskPropertySnapshotEntry[]` and `spec: HdtSpecResponse` as props and joins them locally.

**Tag edits no longer move tabs.** Because tabs derive from observations, not spec tags, editing a property's task tag only updates the chip display without reorganising tabs.

**NO_TASK moved to HdtTaskView.** It is no longer exported from HdtDetail.

Generated with [Claude Code](https://claude.ai/code)