### PR TITLE
feat: searchable DT selectors + loading overlay

### DIFF
--- a/src/app/query-builder/panels/ObservationQueryPanel.tsx
+++ b/src/app/query-builder/panels/ObservationQueryPanel.tsx
@@ -15,6 +15,7 @@ import {
   toWhdtComparisonOp,
 } from "@/app/query-builder/types/query";
 import { HdtScopeSelector } from "@/components/query/HdtScopeSelector";
+import { LoadingOverlay } from "@/components/common/LoadingOverlay";
 
 type ObservationMode = "aggregate" | "search";
 type ValueType = "number" | "string" | "boolean";
@@ -360,7 +361,9 @@ export function ObservationQueryPanel() {
       </div>
 
       {/* Results pane */}
-      <div className="w-1/2">
+      <div className="w-1/2 relative">
+        <LoadingOverlay open={loading} message="Running query…" mode="inline" />
+
         {error && (
           <div className="p-4 bg-red-900 border border-red-600 rounded-lg mb-4 text-red-200">
             {error}

--- a/src/app/query-builder/panels/PropertyTagQueryPanel.tsx
+++ b/src/app/query-builder/panels/PropertyTagQueryPanel.tsx
@@ -6,6 +6,7 @@ import { api } from "@/lib/api/client";
 import { TagPredicateBuilder } from "@/components/query/TagPredicateBuilder";
 import { PropertyTable } from "@/components/query/PropertyTable";
 import { fromPropertyDocument, PropertyRow } from "@/components/query/propertyRow";
+import { LoadingOverlay } from "@/components/common/LoadingOverlay";
 
 export function PropertyTagQueryPanel() {
   const [predicate, setPredicate] = useState<TagPredicate | null>(null);
@@ -65,7 +66,9 @@ export function PropertyTagQueryPanel() {
         </button>
       </div>
 
-      <div className="w-1/2">
+      <div className="w-1/2 relative">
+        <LoadingOverlay open={loading} message="Running query…" mode="inline" />
+
         {error && (
           <div className="p-4 bg-red-900 border border-red-600 rounded-lg mb-4 text-red-200">
             {error}

--- a/src/app/query-builder/panels/ViewsPanel.tsx
+++ b/src/app/query-builder/panels/ViewsPanel.tsx
@@ -6,6 +6,7 @@ import { api } from "@/lib/api/client";
 import { TagPredicateBuilder } from "@/components/query/TagPredicateBuilder";
 import { HdtScopeSelector } from "@/components/query/HdtScopeSelector";
 import { ViewResultTree, ViewNode } from "@/components/query/ViewResultTree";
+import { LoadingOverlay } from "@/components/common/LoadingOverlay";
 
 type ViewDraft = {
   name: string;
@@ -197,17 +198,21 @@ function ExecuteSection({ viewName }: { viewName: string }) {
       >
         {running ? "Running…" : `Execute "${viewName}"`}
       </button>
-      {error && (
-        <div className="p-3 bg-red-900 border border-red-600 rounded text-red-200 text-sm">{error}</div>
-      )}
-      {results !== null && Object.keys(results).length === 0 && !error && (
-        <div className="p-4 bg-gray-700 rounded-lg text-gray-400 text-center text-sm">
-          No results returned.
-        </div>
-      )}
-      {results !== null && Object.keys(results).length > 0 && (
-        <ViewResultTree resultsByHdt={results} />
-      )}
+      <div className="relative">
+        <LoadingOverlay open={running} message="Executing view…" mode="inline" />
+
+        {error && (
+          <div className="p-3 bg-red-900 border border-red-600 rounded text-red-200 text-sm">{error}</div>
+        )}
+        {results !== null && Object.keys(results).length === 0 && !error && (
+          <div className="p-4 bg-gray-700 rounded-lg text-gray-400 text-center text-sm">
+            No results returned.
+          </div>
+        )}
+        {results !== null && Object.keys(results).length > 0 && (
+          <ViewResultTree resultsByHdt={results} />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/HdtManager.tsx
+++ b/src/components/HdtManager.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react";
 import HdtTaskView from "@/components/HdtTaskView";
 import { api } from "@/lib/api/client";
 import { HumanDigitalTwinDocument } from "@/lib/api/schema";
+import { SearchableHdtSelect } from "@/components/common/SearchableHdtSelect";
+import { LoadingOverlay } from "@/components/common/LoadingOverlay";
 
 type ImportMode = "excel" | "json";
 type JsonStatus = { kind: "error" | "success"; message: string } | null;
@@ -26,6 +28,7 @@ export default function HdtManager() {
   const [importMode, setImportMode] = useState<ImportMode>("excel");
   const [jsonText, setJsonText] = useState<string>("");
   const [jsonStatus, setJsonStatus] = useState<JsonStatus>(null);
+  const [creating, setCreating] = useState(false);
 
   const fetchHdts = async () => {
     try {
@@ -47,6 +50,7 @@ export default function HdtManager() {
   const uploadExcel = async () => {
     if (!excelInput) return;
 
+    setCreating(true);
     try {
       const form = new FormData();
       form.append("file", excelInput, excelInput.name); // "file" must match the server fieldName
@@ -66,6 +70,8 @@ export default function HdtManager() {
     } catch (err) {
       console.error("Excel upload failed", err);
       alert("Error reading or uploading Excel file");
+    } finally {
+      setCreating(false);
     }
   }
 
@@ -98,6 +104,7 @@ export default function HdtManager() {
       return;
     }
 
+    setCreating(true);
     try {
       const res = await fetch("/api/creation/hdts/json/batch", {
         method: "POST",
@@ -117,6 +124,8 @@ export default function HdtManager() {
       }
     } catch {
       setJsonStatus({ kind: "error", message: "Request failed — could not reach the creation service" });
+    } finally {
+      setCreating(false);
     }
   };
 
@@ -126,6 +135,8 @@ export default function HdtManager() {
 
   return (
     <div className="p-4 space-y-4">
+      <LoadingOverlay open={creating} message="Creating HDTs…" mode="blocking" />
+
       {/* Import mode toggle */}
       <div className="flex gap-2">
         <button
@@ -207,20 +218,14 @@ export default function HdtManager() {
         {/* HDT List */}
         <div className="w-1/3 bg-gray-800 text-white p-4 rounded shadow">
           <h2 className="text-lg font-semibold mb-2">Available HumanDigitalTwins</h2>
-          <ul className="space-y-1">
-            {hdtList.map((hdt) => {
-              const id = hdt.hdtId
-              return (
-                <li
-                  key={id}
-                  onClick={() => setHighlightedDT(hdt)}
-                  className={`cursor-pointer hover:underline ${highlightedDT?.hdtId === id ? "text-blue-400 font-bold" : "text-white"}`}
-                >
-                  {id}
-                </li>
-              )
-            })}
-          </ul>
+          <SearchableHdtSelect
+            hdtIds={hdtList.map((hdt) => hdt.hdtId)}
+            value={highlightedDT?.hdtId ?? null}
+            onChange={(id) =>
+              setHighlightedDT(hdtList.find((hdt) => hdt.hdtId === id) ?? null)
+            }
+            label="Digital Twin"
+          />
         </div>
 
         {/* HDT Details */}

--- a/src/components/common/LoadingOverlay.tsx
+++ b/src/components/common/LoadingOverlay.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Backdrop from "@mui/material/Backdrop";
+import CircularProgress from "@mui/material/CircularProgress";
+
+type LoadingOverlayProps = {
+  open: boolean;
+  message?: string;
+  mode?: "blocking" | "inline";
+};
+
+export function LoadingOverlay({ open, message, mode = "blocking" }: LoadingOverlayProps) {
+  if (!open) return null;
+
+  if (mode === "inline") {
+    return (
+      <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-gray-900/70">
+        <CircularProgress sx={{ color: "#60a5fa" }} />
+        {message && <p className="text-sm text-gray-200">{message}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <Backdrop
+      open={open}
+      sx={{
+        color: "#fff",
+        zIndex: (theme) => theme.zIndex.drawer + 1,
+        flexDirection: "column",
+        gap: 2,
+      }}
+    >
+      <CircularProgress color="inherit" />
+      {message && <p className="text-sm text-gray-200">{message}</p>}
+    </Backdrop>
+  );
+}

--- a/src/components/common/SearchableHdtSelect.tsx
+++ b/src/components/common/SearchableHdtSelect.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
+
+type Common = {
+  hdtIds: string[];
+  label?: string;
+  disabled?: boolean;
+};
+
+type SingleProps = Common & {
+  multiple?: false;
+  value: string | null;
+  onChange: (v: string | null) => void;
+};
+
+type MultiProps = Common & {
+  multiple: true;
+  value: string[];
+  onChange: (v: string[]) => void;
+};
+
+const darkSx = {
+  "& .MuiOutlinedInput-root": {
+    backgroundColor: "#1f2937",
+    color: "#fff",
+    "& fieldset": {
+      borderColor: "#4b5563",
+    },
+    "&:hover fieldset": {
+      borderColor: "#6b7280",
+    },
+    "&.Mui-focused fieldset": {
+      borderColor: "#60a5fa",
+    },
+  },
+  "& .MuiInputLabel-root": {
+    color: "#9ca3af",
+  },
+  "& .MuiInputLabel-root.Mui-focused": {
+    color: "#60a5fa",
+  },
+  "& .MuiSvgIcon-root": {
+    color: "#d1d5db",
+  },
+  "& .MuiChip-root": {
+    backgroundColor: "#374151",
+    color: "#fff",
+  },
+};
+
+const darkSlotProps = {
+  paper: {
+    sx: {
+      backgroundColor: "#1f2937",
+      color: "#fff",
+      "& .MuiAutocomplete-option": {
+        '&[aria-selected="true"]': {
+          backgroundColor: "#374151",
+        },
+        "&:hover": {
+          backgroundColor: "#374151",
+        },
+      },
+      "& .MuiAutocomplete-noOptions": {
+        color: "#9ca3af",
+      },
+    },
+  },
+};
+
+export function SearchableHdtSelect(props: SingleProps | MultiProps) {
+  const { hdtIds, label, disabled } = props;
+
+  if (props.multiple) {
+    const { value, onChange } = props;
+    return (
+      <Autocomplete
+        multiple
+        disabled={disabled}
+        options={hdtIds}
+        value={value}
+        onChange={(_, next) => onChange(next)}
+        disableCloseOnSelect
+        sx={darkSx}
+        slotProps={darkSlotProps}
+        renderInput={(params) => (
+          <TextField {...params} label={label ?? "Digital Twins"} placeholder="Search…" />
+        )}
+      />
+    );
+  }
+
+  const { value, onChange } = props;
+  return (
+    <Autocomplete
+      disabled={disabled}
+      options={hdtIds}
+      value={value}
+      onChange={(_, next) => onChange(next)}
+      sx={darkSx}
+      slotProps={darkSlotProps}
+      renderInput={(params) => (
+        <TextField {...params} label={label ?? "Digital Twin"} placeholder="Search…" />
+      )}
+    />
+  );
+}

--- a/src/components/query/HdtScopeSelector.tsx
+++ b/src/components/query/HdtScopeSelector.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api/client";
+import { SearchableHdtSelect } from "@/components/common/SearchableHdtSelect";
 
 interface HdtScopeSelectorProps {
   selected: string[];
@@ -28,21 +29,12 @@ export function HdtScopeSelector({ selected, onChange }: HdtScopeSelectorProps) 
   if (hdtIds.length === 0) return <p className="text-gray-400">No digital twins found.</p>;
 
   return (
-    <div className="space-y-1">
-      {hdtIds.map((id) => (
-        <label key={id} className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={selected.includes(id)}
-            onChange={(e) =>
-              onChange(
-                e.target.checked ? [...selected, id] : selected.filter((x) => x !== id)
-              )
-            }
-          />
-          <span>{id}</span>
-        </label>
-      ))}
-    </div>
+    <SearchableHdtSelect
+      multiple
+      hdtIds={hdtIds}
+      value={selected}
+      onChange={onChange}
+      label="Digital Twins"
+    />
   );
 }


### PR DESCRIPTION
Adds a searchable dropdown (SearchableHdtSelect) for choosing Digital Twins and a loading overlay (LoadingOverlay) for long-running operations. HdtScopeSelector and HdtManager's list now use the new selector; HDT creation and query result panes use the new overlay. Closes #40. Generated with Claude Code (https://claude.ai/code)