### PR TITLE
feat: render population stats in Search DTs results

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -710,9 +710,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PropertiesByComparisonsAggregateResponse'
+                $ref: '#/components/schemas/ComparisonSearchResult'
 components:
   schemas:
     TagPredicate:
@@ -1604,6 +1602,56 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EventMatch'
+    PropertyPopulationStats:
+      type: object
+      title: io.github.whdt.routing.query.event.comparison.PropertyPopulationStats
+      required:
+      - propertyName
+      - count
+      properties:
+        propertyName:
+          type: string
+        count:
+          type: integer
+        avg:
+          type:
+          - number
+          - 'null'
+        min:
+          type:
+          - number
+          - 'null'
+        max:
+          type:
+          - number
+          - 'null'
+        median:
+          type:
+          - number
+          - 'null'
+        p25:
+          type:
+          - number
+          - 'null'
+        p75:
+          type:
+          - number
+          - 'null'
+    ComparisonSearchResult:
+      type: object
+      title: io.github.whdt.routing.query.event.comparison.ComparisonSearchResult
+      required:
+      - matches
+      - populationStats
+      properties:
+        matches:
+          type: array
+          items:
+            $ref: '#/components/schemas/PropertiesByComparisonsAggregateResponse'
+        populationStats:
+          type: array
+          items:
+            $ref: '#/components/schemas/PropertyPopulationStats'
     View:
       type: object
       title: io.github.whdt.core.hdt.view.View

--- a/src/app/query-builder/panels/ObservationQueryPanel.tsx
+++ b/src/app/query-builder/panels/ObservationQueryPanel.tsx
@@ -2,20 +2,56 @@
 
 import { useEffect, useState, type ReactNode } from "react";
 import {
-  PropertiesByComparisonsAggregateResponse,
   PropertiesByComparisonsRequestDto,
   PropertyComparisonDto,
+  PropertyPopulationStats,
   PropertyStatsRequest,
 } from "@/lib/api/schema";
 import { api } from "@/lib/api/client";
 import { distinct } from "@/util/utils";
-import {
-  AggregateOperation,
-  FilterOperator,
-  toWhdtComparisonOp,
-} from "@/app/query-builder/types/query";
+import { FilterOperator, toWhdtComparisonOp } from "@/app/query-builder/types/query";
 import { HdtScopeSelector } from "@/components/query/HdtScopeSelector";
 import { LoadingOverlay } from "@/components/common/LoadingOverlay";
+
+const fmt = (n?: number | null) => (n == null ? "—" : n.toFixed(2));
+
+function PopulationStatsTable({ stats }: { stats: PropertyPopulationStats[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm rounded-lg overflow-hidden shadow-md">
+        <thead className="bg-gray-700">
+          <tr>
+            {["Property", "Count", "Avg", "Min", "Max", "Median", "P25", "P75"].map(
+              (col) => (
+                <th key={col} className="px-4 py-2 text-left">
+                  {col}
+                </th>
+              )
+            )}
+          </tr>
+        </thead>
+
+        <tbody>
+          {stats.map((s) => (
+            <tr
+              key={s.propertyName}
+              className="border-t border-gray-700 hover:bg-gray-700"
+            >
+              <td className="px-4 py-2">{s.propertyName}</td>
+              <td className="px-4 py-2">{s.count}</td>
+              <td className="px-4 py-2">{fmt(s.avg)}</td>
+              <td className="px-4 py-2">{fmt(s.min)}</td>
+              <td className="px-4 py-2">{fmt(s.max)}</td>
+              <td className="px-4 py-2">{fmt(s.median)}</td>
+              <td className="px-4 py-2">{fmt(s.p25)}</td>
+              <td className="px-4 py-2">{fmt(s.p75)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
 
 type ObservationMode = "aggregate" | "search";
 type ValueType = "number" | "string" | "boolean";
@@ -39,7 +75,6 @@ function toIso(local: string): string {
 
 export function ObservationQueryPanel() {
   const [mode, setMode] = useState<ObservationMode>("aggregate");
-  const [operation, setOperation] = useState<AggregateOperation>("avg");
   const [property, setProperty] = useState("");
   const [selectedHdtIds, setSelectedHdtIds] = useState<string[]>([]);
   const [models, setModels] = useState<string[]>([]);
@@ -48,6 +83,7 @@ export function ObservationQueryPanel() {
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
   const [results, setResults] = useState<Record<string, unknown>[]>([]);
+  const [populationStats, setPopulationStats] = useState<PropertyPopulationStats[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [empty, setEmpty] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -83,6 +119,7 @@ export function ObservationQueryPanel() {
     setError(null);
     setEmpty(false);
     setResults([]);
+    setPopulationStats([]);
     setLoading(true);
 
     try {
@@ -132,20 +169,28 @@ export function ObservationQueryPanel() {
           return;
         }
 
-        if (!data || data.length === 0) {
+        if (!data || data.matches.length === 0) {
           setEmpty(true);
           return;
         }
 
-        const rows = data.map((match: PropertiesByComparisonsAggregateResponse) => {
+        const rows = data.matches.map((match) => {
           const row: Record<string, unknown> = { hdtId: match.hdtId };
+          const latestByProperty = new Map<string, (typeof match.matchedEvents)[number]>();
           match.matchedEvents?.forEach((e) => {
-            row[e.propertyName] = (e.value as { value: unknown }).value;
+            const current = latestByProperty.get(e.propertyName);
+            if (!current || e.timeField > current.timeField) {
+              latestByProperty.set(e.propertyName, e);
+            }
+          });
+          latestByProperty.forEach((e, propertyName) => {
+            row[propertyName] = (e.value as { value: unknown }).value;
           });
           return row;
         });
 
         setResults(rows);
+        setPopulationStats(data.populationStats ?? []);
       }
     } catch {
       setError("Unexpected error occurred.");
@@ -154,16 +199,34 @@ export function ObservationQueryPanel() {
     }
   };
 
+  const downloadCSV = (content: string, filename: string) => {
+    const blob = new Blob([content], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   const exportToCSV = () => {
     if (results.length === 0) return;
     const headers = Object.keys(results[0]).join(",");
     const rows = results.map((row) => Object.values(row).join(",")).join("\n");
-    const blob = new Blob([headers + "\n" + rows], { type: "text/csv" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "query-results.csv";
-    link.click();
+    downloadCSV(headers + "\n" + rows, "query-results.csv");
+  };
+
+  const exportPopulationStatsToCSV = () => {
+    if (populationStats.length === 0) return;
+    const headers = "propertyName,count,avg,min,max,median,p25,p75";
+    const rows = populationStats
+      .map((s) =>
+        [s.propertyName, s.count, s.avg, s.min, s.max, s.median, s.p25, s.p75]
+          .map((v) => (v == null ? "" : v))
+          .join(",")
+      )
+      .join("\n");
+    downloadCSV(headers + "\n" + rows, "population-stats.csv");
   };
 
   return (
@@ -183,24 +246,6 @@ export function ObservationQueryPanel() {
             </button>
           ))}
         </div>
-
-        {/* Aggregate operation */}
-        {mode === "aggregate" && (
-          <div className="mb-6 p-4 bg-gray-700 rounded-lg">
-            <label className="block mb-2 font-semibold">Operation</label>
-            {(["avg", "min", "max"] as AggregateOperation[]).map((op) => (
-              <button
-                key={op}
-                onClick={() => setOperation(op)}
-                className={`mr-2 px-4 py-2 rounded ${
-                  operation === op ? "bg-blue-600" : "bg-gray-600 hover:bg-gray-500"
-                }`}
-              >
-                {op}
-              </button>
-            ))}
-          </div>
-        )}
 
         {/* Property name */}
         {mode === "aggregate" && (
@@ -414,6 +459,21 @@ export function ObservationQueryPanel() {
               className="mt-4 bg-green-600 hover:bg-green-500 transition px-6 py-2 rounded-lg font-semibold"
             >
               Export CSV
+            </button>
+          </div>
+        )}
+
+        {mode === "search" && populationStats.length > 0 && (
+          <div className="mt-8">
+            <h2 className="text-lg font-bold mb-4">Population Stats</h2>
+
+            <PopulationStatsTable stats={populationStats} />
+
+            <button
+              onClick={exportPopulationStatsToCSV}
+              className="mt-4 bg-green-600 hover:bg-green-500 transition px-6 py-2 rounded-lg font-semibold"
+            >
+              Export Population Stats CSV
             </button>
           </div>
         )}

--- a/src/app/query-builder/types/query.ts
+++ b/src/app/query-builder/types/query.ts
@@ -1,7 +1,5 @@
 import { PropertyComparisonDto } from "@/lib/api/schema";
 
-export type AggregateOperation = "avg" | "min" | "max";
-
 export type FilterOperator = "<" | ">" | "=" | "<=" | ">=";
 
 type ComparisonOp = PropertyComparisonDto["comparison"];

--- a/src/lib/api/schema.d.ts
+++ b/src/lib/api/schema.d.ts
@@ -892,6 +892,22 @@ export interface components {
             matchedProperties: string[];
             matchedEvents: components["schemas"]["EventMatch"][];
         };
+        /** io.github.whdt.routing.query.event.comparison.PropertyPopulationStats */
+        PropertyPopulationStats: {
+            propertyName: string;
+            count: number;
+            avg?: number | null;
+            min?: number | null;
+            max?: number | null;
+            median?: number | null;
+            p25?: number | null;
+            p75?: number | null;
+        };
+        /** io.github.whdt.routing.query.event.comparison.ComparisonSearchResult */
+        ComparisonSearchResult: {
+            matches: components["schemas"]["PropertiesByComparisonsAggregateResponse"][];
+            populationStats: components["schemas"]["PropertyPopulationStats"][];
+        };
         /** io.github.whdt.core.hdt.view.View */
         View: {
             name: string;
@@ -993,6 +1009,8 @@ export type PropertyComparison = components['schemas']['PropertyComparison'];
 export type PropertiesByComparisonsAggregateRequest = components['schemas']['PropertiesByComparisonsAggregateRequest'];
 export type EventMatch = components['schemas']['EventMatch'];
 export type PropertiesByComparisonsAggregateResponse = components['schemas']['PropertiesByComparisonsAggregateResponse'];
+export type PropertyPopulationStats = components['schemas']['PropertyPopulationStats'];
+export type ComparisonSearchResult = components['schemas']['ComparisonSearchResult'];
 export type View = components['schemas']['View'];
 export type ViewDocument = components['schemas']['ViewDocument'];
 export type ViewResult = components['schemas']['ViewResult'];
@@ -2003,7 +2021,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PropertiesByComparisonsAggregateResponse"][];
+                    "application/json": components["schemas"]["ComparisonSearchResult"];
                 };
             };
         };


### PR DESCRIPTION
## Summary
- Regenerate `schema.d.ts` from the updated persistence spec, adding `ComparisonSearchResult` / `PropertyPopulationStats`
- Search DTs now renders a Population Stats table (count/avg/min/max/median/p25/p75) per filtered property, alongside the matched-DT results
- Matched-DT rows pick the latest event by `timeField` per property for deterministic values
- Population stats are exportable as a separate CSV
- Removed the vestigial avg/min/max "Operation" toggle from the Aggregate sub-panel

Closes #42

## Test plan
- [x] `npm run lint` exits 0
- [x] `npm run build` exits 0
- [ ] Manually verify in a browser against a live persistence service: Search DTs renders both matched-DT and population-stats tables, numbers formatted correctly, CSV exports work, Aggregate panel no longer shows the operation toggle

🤖 Generated with [Claude Code](https://claude.ai/code)