### PR TITLE
refactor: collapsible cohort data frame for Search DTs + Excel export

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -711,6 +711,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ComparisonSearchResult'
+  /query/cohort:
+    post:
+      operationId: query/cohort
+      summary: Query cohort frame (per-DT values + stats + population summary) by comparisons
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PropertiesByComparisonsRequestDto'
+      responses:
+        '200':
+          description: POST /query/cohort response 200
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CohortResult'
 components:
   schemas:
     TagPredicate:
@@ -1648,6 +1664,72 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PropertiesByComparisonsAggregateResponse'
+        populationStats:
+          type: array
+          items:
+            $ref: '#/components/schemas/PropertyPopulationStats'
+    CohortPropertyCell:
+      type: object
+      title: io.github.whdt.routing.query.event.cohort.CohortPropertyCell
+      required:
+      - propertyName
+      - count
+      properties:
+        propertyName:
+          type: string
+        value:
+          $ref: '#/components/schemas/PropertyValue'
+          nullable: true
+        count:
+          type: integer
+        avg:
+          type:
+          - number
+          - 'null'
+        min:
+          type:
+          - number
+          - 'null'
+        max:
+          type:
+          - number
+          - 'null'
+        median:
+          type:
+          - number
+          - 'null'
+        p25:
+          type:
+          - number
+          - 'null'
+        p75:
+          type:
+          - number
+          - 'null'
+    CohortRow:
+      type: object
+      title: io.github.whdt.routing.query.event.cohort.CohortRow
+      required:
+      - hdtId
+      - properties
+      properties:
+        hdtId:
+          type: string
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/CohortPropertyCell'
+    CohortResult:
+      type: object
+      title: io.github.whdt.routing.query.event.cohort.CohortResult
+      required:
+      - rows
+      - populationStats
+      properties:
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/CohortRow'
         populationStats:
           type: array
           items:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "openapi-fetch": "^0.17.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "recharts": "^3.1.0"
+        "recharts": "^3.1.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2927,6 +2928,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3456,6 +3466,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3564,6 +3587,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color": {
@@ -3765,6 +3797,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -5111,6 +5155,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -8150,6 +8203,18 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -8984,6 +9049,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -9061,6 +9144,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "openapi-fetch": "^0.17.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "recharts": "^3.1.0"
+    "recharts": "^3.1.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/query-builder/panels/ObservationQueryPanel.tsx
+++ b/src/app/query-builder/panels/ObservationQueryPanel.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useState, type ReactNode } from "react";
 import {
+  CohortResult,
   PropertiesByComparisonsRequestDto,
   PropertyComparisonDto,
-  PropertyPopulationStats,
   PropertyStatsRequest,
 } from "@/lib/api/schema";
 import { api } from "@/lib/api/client";
@@ -12,46 +12,9 @@ import { distinct } from "@/util/utils";
 import { FilterOperator, toWhdtComparisonOp } from "@/app/query-builder/types/query";
 import { HdtScopeSelector } from "@/components/query/HdtScopeSelector";
 import { LoadingOverlay } from "@/components/common/LoadingOverlay";
-
-const fmt = (n?: number | null) => (n == null ? "—" : n.toFixed(2));
-
-function PopulationStatsTable({ stats }: { stats: PropertyPopulationStats[] }) {
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm rounded-lg overflow-hidden shadow-md">
-        <thead className="bg-gray-700">
-          <tr>
-            {["Property", "Count", "Avg", "Min", "Max", "Median", "P25", "P75"].map(
-              (col) => (
-                <th key={col} className="px-4 py-2 text-left">
-                  {col}
-                </th>
-              )
-            )}
-          </tr>
-        </thead>
-
-        <tbody>
-          {stats.map((s) => (
-            <tr
-              key={s.propertyName}
-              className="border-t border-gray-700 hover:bg-gray-700"
-            >
-              <td className="px-4 py-2">{s.propertyName}</td>
-              <td className="px-4 py-2">{s.count}</td>
-              <td className="px-4 py-2">{fmt(s.avg)}</td>
-              <td className="px-4 py-2">{fmt(s.min)}</td>
-              <td className="px-4 py-2">{fmt(s.max)}</td>
-              <td className="px-4 py-2">{fmt(s.median)}</td>
-              <td className="px-4 py-2">{fmt(s.p25)}</td>
-              <td className="px-4 py-2">{fmt(s.p75)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
+import { CohortTable } from "@/components/query/cohort/CohortTable";
+import { deriveCohortColumns } from "@/components/query/cohort/shared";
+import { exportCohortToExcel } from "@/components/query/cohort/exportToExcel";
 
 type ObservationMode = "aggregate" | "search";
 type ValueType = "number" | "string" | "boolean";
@@ -83,7 +46,7 @@ export function ObservationQueryPanel() {
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
   const [results, setResults] = useState<Record<string, unknown>[]>([]);
-  const [populationStats, setPopulationStats] = useState<PropertyPopulationStats[]>([]);
+  const [cohortResult, setCohortResult] = useState<CohortResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [empty, setEmpty] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -119,7 +82,7 @@ export function ObservationQueryPanel() {
     setError(null);
     setEmpty(false);
     setResults([]);
-    setPopulationStats([]);
+    setCohortResult(null);
     setLoading(true);
 
     try {
@@ -162,35 +125,19 @@ export function ObservationQueryPanel() {
           ...(to ? { to: toIso(to) } : {}),
         };
 
-        const { data, error: err } = await api.POST("/query/event/comparison", { body });
+        const { data, error: err } = await api.POST("/query/cohort", { body });
 
         if (err) {
           setError("Request failed");
           return;
         }
 
-        if (!data || data.matches.length === 0) {
+        if (!data || data.rows.length === 0) {
           setEmpty(true);
           return;
         }
 
-        const rows = data.matches.map((match) => {
-          const row: Record<string, unknown> = { hdtId: match.hdtId };
-          const latestByProperty = new Map<string, (typeof match.matchedEvents)[number]>();
-          match.matchedEvents?.forEach((e) => {
-            const current = latestByProperty.get(e.propertyName);
-            if (!current || e.timeField > current.timeField) {
-              latestByProperty.set(e.propertyName, e);
-            }
-          });
-          latestByProperty.forEach((e, propertyName) => {
-            row[propertyName] = (e.value as { value: unknown }).value;
-          });
-          return row;
-        });
-
-        setResults(rows);
-        setPopulationStats(data.populationStats ?? []);
+        setCohortResult(data);
       }
     } catch {
       setError("Unexpected error occurred.");
@@ -216,17 +163,14 @@ export function ObservationQueryPanel() {
     downloadCSV(headers + "\n" + rows, "query-results.csv");
   };
 
-  const exportPopulationStatsToCSV = () => {
-    if (populationStats.length === 0) return;
-    const headers = "propertyName,count,avg,min,max,median,p25,p75";
-    const rows = populationStats
-      .map((s) =>
-        [s.propertyName, s.count, s.avg, s.min, s.max, s.median, s.p25, s.p75]
-          .map((v) => (v == null ? "" : v))
-          .join(",")
-      )
-      .join("\n");
-    downloadCSV(headers + "\n" + rows, "population-stats.csv");
+  const filteredPropertyNames = filters
+    .filter((f) => f.propertyName.trim() !== "")
+    .map((f) => f.propertyName);
+
+  const exportCohortToExcelFile = () => {
+    if (!cohortResult) return;
+    const columns = deriveCohortColumns(cohortResult.populationStats, filteredPropertyNames);
+    exportCohortToExcel(cohortResult, columns, "cohort.xlsx");
   };
 
   return (
@@ -421,7 +365,7 @@ export function ObservationQueryPanel() {
           </div>
         )}
 
-        {results.length > 0 && (
+        {mode === "aggregate" && results.length > 0 && (
           <div>
             <h2 className="text-lg font-bold mb-4">Query Results</h2>
 
@@ -463,17 +407,17 @@ export function ObservationQueryPanel() {
           </div>
         )}
 
-        {mode === "search" && populationStats.length > 0 && (
-          <div className="mt-8">
-            <h2 className="text-lg font-bold mb-4">Population Stats</h2>
+        {mode === "search" && cohortResult && (
+          <div>
+            <h2 className="text-lg font-bold mb-4">Cohort Results</h2>
 
-            <PopulationStatsTable stats={populationStats} />
+            <CohortTable data={cohortResult} filteredPropertyNames={filteredPropertyNames} />
 
             <button
-              onClick={exportPopulationStatsToCSV}
+              onClick={exportCohortToExcelFile}
               className="mt-4 bg-green-600 hover:bg-green-500 transition px-6 py-2 rounded-lg font-semibold"
             >
-              Export Population Stats CSV
+              Export Excel
             </button>
           </div>
         )}

--- a/src/components/query/cohort/CohortTable.tsx
+++ b/src/components/query/cohort/CohortTable.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { Fragment, useMemo, useState } from "react";
+import { CohortResult } from "@/lib/api/schema";
+import {
+  STAT_COLS,
+  STAT_LABELS,
+  cellFor,
+  deriveCohortColumns,
+  fmtStat,
+  rawCellValue,
+} from "./shared";
+
+const ROWS_PER_PAGE = 25;
+
+export function CohortTable({
+  data,
+  filteredPropertyNames,
+}: {
+  data: CohortResult;
+  filteredPropertyNames: string[];
+}) {
+  const columns = useMemo(
+    () => deriveCohortColumns(data.populationStats, filteredPropertyNames),
+    [data.populationStats, filteredPropertyNames]
+  );
+  const popStatsByName = useMemo(
+    () => new Map(data.populationStats.map((s) => [s.propertyName, s])),
+    [data.populationStats]
+  );
+
+  const [expandedCols, setExpandedCols] = useState<Set<string>>(new Set());
+  const [showRows, setShowRows] = useState(false);
+  const [page, setPage] = useState(0);
+
+  const toggleCol = (name: string) => {
+    setExpandedCols((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const totalPages = Math.max(1, Math.ceil(data.rows.length / ROWS_PER_PAGE));
+  const pageRows = data.rows.slice(page * ROWS_PER_PAGE, page * ROWS_PER_PAGE + ROWS_PER_PAGE);
+
+  return (
+    <div>
+      <div className="overflow-auto max-h-[70vh] rounded-lg shadow-md">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-700">
+            <tr>
+              <th className="px-4 py-2 text-left align-bottom" rowSpan={2}>
+                DT
+              </th>
+              {columns.map((col) => {
+                const open = expandedCols.has(col.name);
+                return (
+                  <th
+                    key={col.name}
+                    colSpan={open ? 1 + STAT_COLS.length : 1}
+                    className={`px-4 py-2 text-left cursor-pointer select-none whitespace-nowrap ${
+                      col.filtered ? "bg-blue-900/60" : ""
+                    }`}
+                    onClick={() => toggleCol(col.name)}
+                  >
+                    {open ? "▾" : "▸"} {col.name}
+                  </th>
+                );
+              })}
+            </tr>
+            <tr>
+              {columns.map((col) => {
+                const open = expandedCols.has(col.name);
+                return (
+                  <Fragment key={col.name}>
+                    <th
+                      className={`px-4 py-2 text-left text-xs font-normal whitespace-nowrap ${
+                        col.filtered ? "bg-blue-900/40" : ""
+                      }`}
+                    >
+                      Value
+                    </th>
+                    {open &&
+                      STAT_COLS.map((s) => (
+                        <th
+                          key={s}
+                          className="px-4 py-2 text-left text-xs font-normal whitespace-nowrap"
+                        >
+                          {STAT_LABELS[s]}
+                        </th>
+                      ))}
+                  </Fragment>
+                );
+              })}
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr className="sticky top-0 z-10 bg-gray-800 font-bold border-t-2 border-b-2 border-gray-500">
+              <td className="px-4 py-2">Population</td>
+              {columns.map((col) => {
+                const open = expandedCols.has(col.name);
+                const stats = popStatsByName.get(col.name);
+                return (
+                  <Fragment key={col.name}>
+                    <td className="px-4 py-2">—</td>
+                    {open &&
+                      STAT_COLS.map((s) => (
+                        <td key={s} className="px-4 py-2">
+                          {fmtStat(stats, s)}
+                        </td>
+                      ))}
+                  </Fragment>
+                );
+              })}
+            </tr>
+
+            {showRows &&
+              pageRows.map((row) => (
+                <tr key={row.hdtId} className="border-t border-gray-700 hover:bg-gray-700">
+                  <td className="px-4 py-2 font-mono text-xs">{row.hdtId}</td>
+                  {columns.map((col) => {
+                    const open = expandedCols.has(col.name);
+                    const cell = cellFor(row, col.name);
+                    const value = rawCellValue(cell);
+                    return (
+                      <Fragment key={col.name}>
+                        <td className="px-4 py-2">{value == null ? "—" : String(value)}</td>
+                        {open &&
+                          STAT_COLS.map((s) => (
+                            <td key={s} className="px-4 py-2">
+                              {fmtStat(cell, s)}
+                            </td>
+                          ))}
+                      </Fragment>
+                    );
+                  })}
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 flex items-center gap-4 flex-wrap">
+        <button
+          onClick={() => {
+            setShowRows((v) => !v);
+            setPage(0);
+          }}
+          className="bg-gray-600 hover:bg-gray-500 transition px-4 py-2 rounded text-sm font-semibold"
+        >
+          {showRows ? "Hide" : "Show"} individual DTs (n={data.rows.length})
+        </button>
+
+        {showRows && totalPages > 1 && (
+          <div className="flex items-center gap-2 text-sm">
+            <button
+              disabled={page === 0}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              className="px-3 py-1 bg-gray-700 rounded disabled:opacity-40"
+            >
+              Prev
+            </button>
+            <span>
+              Page {page + 1} / {totalPages}
+            </span>
+            <button
+              disabled={page >= totalPages - 1}
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              className="px-3 py-1 bg-gray-700 rounded disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/query/cohort/exportToExcel.ts
+++ b/src/components/query/cohort/exportToExcel.ts
@@ -1,0 +1,70 @@
+import * as XLSX from "xlsx";
+import { CohortResult } from "@/lib/api/schema";
+import {
+  CohortColumn,
+  STAT_COLS,
+  STAT_LABELS,
+  cellFor,
+  fmtStat,
+  rawCellValue,
+} from "./shared";
+
+type CellRange = { s: { r: number; c: number }; e: { r: number; c: number } };
+
+export function exportCohortToExcel(
+  data: CohortResult,
+  columns: CohortColumn[],
+  filename = "cohort.xlsx"
+) {
+  const popStatsByName = new Map(data.populationStats.map((s) => [s.propertyName, s]));
+
+  const header1: (string | number)[] = ["DT"];
+  const header2: (string | number)[] = [""];
+  columns.forEach((col) => {
+    header1.push(col.name, ...STAT_COLS.map(() => ""));
+    header2.push("Value", ...STAT_COLS.map((s) => STAT_LABELS[s]));
+  });
+
+  const popRow: (string | number)[] = ["Population"];
+  columns.forEach((col) => {
+    const stats = popStatsByName.get(col.name);
+    popRow.push("—", ...STAT_COLS.map((s) => fmtStat(stats, s)));
+  });
+
+  const dataRows = data.rows.map((row) => {
+    const cells: (string | number)[] = [row.hdtId];
+    columns.forEach((col) => {
+      const cell = cellFor(row, col.name);
+      const value = rawCellValue(cell);
+      cells.push(
+        value == null ? "—" : typeof value === "boolean" ? String(value) : value,
+        ...STAT_COLS.map((s) => fmtStat(cell, s))
+      );
+    });
+    return cells;
+  });
+
+  const aoa = [header1, header2, popRow, ...dataRows];
+  const ws = XLSX.utils.aoa_to_sheet(aoa);
+
+  const merges: CellRange[] = [{ s: { r: 0, c: 0 }, e: { r: 1, c: 0 } }];
+  let col = 1;
+  columns.forEach(() => {
+    merges.push({ s: { r: 0, c: col }, e: { r: 0, c: col + STAT_COLS.length } });
+    col += STAT_COLS.length + 1;
+  });
+  ws["!merges"] = merges;
+
+  const range = XLSX.utils.decode_range(ws["!ref"] ?? "A1");
+  for (let c = range.s.c; c <= range.e.c; c++) {
+    const addr = XLSX.utils.encode_cell({ r: 2, c });
+    const target = ws[addr];
+    if (target) {
+      target.s = { font: { bold: true } };
+    }
+  }
+
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "Cohort");
+  XLSX.writeFile(wb, filename);
+}

--- a/src/components/query/cohort/shared.ts
+++ b/src/components/query/cohort/shared.ts
@@ -1,0 +1,60 @@
+import { CohortPropertyCell, CohortRow } from "@/lib/api/schema";
+import { distinct } from "@/util/utils";
+
+export const STAT_COLS = ["count", "avg", "min", "max", "median", "p25", "p75"] as const;
+export type StatCol = (typeof STAT_COLS)[number];
+
+export const STAT_LABELS: Record<StatCol, string> = {
+  count: "Count",
+  avg: "Avg",
+  min: "Min",
+  max: "Max",
+  median: "Median",
+  p25: "P25",
+  p75: "P75",
+};
+
+export type StatBearing = {
+  count: number;
+  avg?: number | null;
+  min?: number | null;
+  max?: number | null;
+  median?: number | null;
+  p25?: number | null;
+  p75?: number | null;
+};
+
+export const fmt = (n?: number | null) => (n == null ? "—" : n.toFixed(2));
+
+export function fmtStat(source: StatBearing | undefined, stat: StatCol): string {
+  if (!source) return "—";
+  return stat === "count" ? String(source.count) : fmt(source[stat]);
+}
+
+export type CohortColumn = { name: string; filtered: boolean };
+
+/** Columns come from populationStats (the canonical set); filtered properties surface first, in filter order. */
+export function deriveCohortColumns(
+  populationStats: { propertyName: string }[],
+  filteredPropertyNames: string[]
+): CohortColumn[] {
+  const names = distinct(populationStats.map((s) => s.propertyName));
+  const nameSet = new Set(names);
+  const filteredOrder = distinct(filteredPropertyNames.filter((n) => nameSet.has(n)));
+  const filteredSet = new Set(filteredOrder);
+  const rest = names.filter((n) => !filteredSet.has(n)).sort((a, b) => a.localeCompare(b));
+  return [
+    ...filteredOrder.map((name) => ({ name, filtered: true })),
+    ...rest.map((name) => ({ name, filtered: false })),
+  ];
+}
+
+export function cellFor(row: CohortRow, propertyName: string): CohortPropertyCell | undefined {
+  return row.properties.find((p) => p.propertyName === propertyName);
+}
+
+export function rawCellValue(cell?: CohortPropertyCell): string | number | boolean | undefined {
+  const v = cell?.value;
+  if (v && "value" in v) return v.value;
+  return undefined;
+}

--- a/src/lib/api/schema.d.ts
+++ b/src/lib/api/schema.d.ts
@@ -493,6 +493,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/query/cohort": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Query cohort frame (per-DT values + stats + population summary) by comparisons */
+        post: operations["query/cohort"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -908,6 +925,28 @@ export interface components {
             matches: components["schemas"]["PropertiesByComparisonsAggregateResponse"][];
             populationStats: components["schemas"]["PropertyPopulationStats"][];
         };
+        /** io.github.whdt.routing.query.event.cohort.CohortPropertyCell */
+        CohortPropertyCell: {
+            propertyName: string;
+            value?: components["schemas"]["PropertyValue"];
+            count: number;
+            avg?: number | null;
+            min?: number | null;
+            max?: number | null;
+            median?: number | null;
+            p25?: number | null;
+            p75?: number | null;
+        };
+        /** io.github.whdt.routing.query.event.cohort.CohortRow */
+        CohortRow: {
+            hdtId: string;
+            properties: components["schemas"]["CohortPropertyCell"][];
+        };
+        /** io.github.whdt.routing.query.event.cohort.CohortResult */
+        CohortResult: {
+            rows: components["schemas"]["CohortRow"][];
+            populationStats: components["schemas"]["PropertyPopulationStats"][];
+        };
         /** io.github.whdt.core.hdt.view.View */
         View: {
             name: string;
@@ -1011,6 +1050,9 @@ export type EventMatch = components['schemas']['EventMatch'];
 export type PropertiesByComparisonsAggregateResponse = components['schemas']['PropertiesByComparisonsAggregateResponse'];
 export type PropertyPopulationStats = components['schemas']['PropertyPopulationStats'];
 export type ComparisonSearchResult = components['schemas']['ComparisonSearchResult'];
+export type CohortPropertyCell = components['schemas']['CohortPropertyCell'];
+export type CohortRow = components['schemas']['CohortRow'];
+export type CohortResult = components['schemas']['CohortResult'];
 export type View = components['schemas']['View'];
 export type ViewDocument = components['schemas']['ViewDocument'];
 export type ViewResult = components['schemas']['ViewResult'];
@@ -2022,6 +2064,30 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ComparisonSearchResult"];
+                };
+            };
+        };
+    };
+    "query/cohort": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PropertiesByComparisonsRequestDto"];
+            };
+        };
+        responses: {
+            /** @description POST /query/cohort response 200 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CohortResult"];
                 };
             };
         };


### PR DESCRIPTION
Closes #44.

Refactors the Search DTs mode of the Observation query panel to render results as a collapsible cohort data frame (DTs × properties, collapsible stat columns, sticky population row) with full-frame Excel export, replacing the Issue C population-stats table.

- Points `mode === "search"` submit at `POST /query/cohort`
- New `CohortTable` (hand-rolled, no external table lib): collapsible column groups, sticky population row, paginated per-DT rows behind a toggle
- SheetJS `.xlsx` export of the full frame with merged group headers and a bold population row
- Regenerated `schema.d.ts` from the #D openapi spec (not hand-edited)

Depends on #D, supersedes the Issue C population-stats rendering.

Generated with [Claude Code](https://claude.ai/code)