### PR TITLE
Format FLOAT/DOUBLE property values in HDT detail table

### DIFF
--- a/src/components/HdtDetail.tsx
+++ b/src/components/HdtDetail.tsx
@@ -25,6 +25,19 @@ type DisplayRow = {
   declaredType?: string;
 };
 
+function formatPropertyValue(row: DisplayRow): string {
+  const raw = row.value != null ? (row.value as { value?: unknown }).value : undefined;
+  if (raw == null) return "—";
+  if (
+    (row.declaredType === "FLOAT" || row.declaredType === "DOUBLE") &&
+    typeof raw === "number"
+  ) {
+    const decimals = row.modelName.toLowerCase() === "info" ? 1 : 2;
+    return raw.toFixed(decimals);
+  }
+  return String(raw);
+}
+
 export default function HdtDetail({ id, entries, spec, onTagSaved }: HdtDetailProps) {
   const router = useRouter();
   const [search, setSearch] = useState("");
@@ -147,9 +160,7 @@ export default function HdtDetail({ id, entries, spec, onTagSaved }: HdtDetailPr
                 <td className="p-2 border border-gray-700">{row.modelName}</td>
                 <td className="p-2 border border-gray-700">{row.propertyName}</td>
                 <td className="p-2 border border-gray-700">
-                  {row.value != null
-                    ? String((row.value as { value?: unknown }).value ?? "—")
-                    : "—"}
+                  {formatPropertyValue(row)}
                 </td>
                 <td className="p-2 border border-gray-700">
                   {row.timestamp ? new Date(row.timestamp).toDateString() : "—"}


### PR DESCRIPTION
## Summary
- In `HdtDetail.tsx`'s property value cell, FLOAT/DOUBLE values now render with 1 decimal place when the model name is `info` (case-insensitive), and 2 decimals otherwise.
- INT/LONG/STRING/BOOLEAN values are unaffected — they still render via `String(value)`.
- Cohort tables use their own `fmt` helper (`src/components/query/cohort/shared.ts`) and are untouched.

## Test plan
- [ ] Load an HDT with `info`-model FLOAT/DOUBLE properties and confirm they render to 1 decimal in the detail table
- [ ] Load an HDT with non-`info`-model FLOAT/DOUBLE properties and confirm 2 decimals
- [ ] Confirm INT/LONG/STRING/BOOLEAN properties render unchanged
- [ ] Confirm cohort table values are unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01HYX1ZBb7sxtdSUAMZDjjqz)_