### PR TITLE
Plot property-live chart by age, add task filter and months/years toggle

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1258,6 +1258,7 @@ components:
       - metaField
       - timeField
       - value
+      - metadata
       properties:
         metaField:
           $ref: '#/components/schemas/PropertyEventMetadata'
@@ -1266,6 +1267,10 @@ components:
           format: date-time
         value:
           $ref: '#/components/schemas/PropertyValue'
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
     PropertyObservation:
       type: object
       title: io.github.whdt.core.hdt.model.property.PropertyObservation

--- a/src/app/hdt/[id]/property-live/page.tsx
+++ b/src/app/hdt/[id]/property-live/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { use, useEffect, useMemo, useState } from "react";
-import LiveLineChart from "@/components/LiveLineChart";
+import LiveLineChart, { ALL_TASKS, AgeUnit } from "@/components/LiveLineChart";
 import { Filter } from "@/components/Filter";
 import { HdtSpecResponse, PropertyObservationDocument, PropertySpecEntry } from "@/lib/api/schema";
 import { api } from "@/lib/api/client";
@@ -34,6 +34,8 @@ export default function PropertyLiveUpdatePage({ params }: { params: Promise<{ i
   const [selectedProperty, setSelectedProperty] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [propertyHistory, setPropertyHistory] = useState<PropertyObservationDocument[]>([]);
+  const [taskFilter, setTaskFilter] = useState<string>(ALL_TASKS);
+  const [ageUnit, setAgeUnit] = useState<AgeUnit>("months");
 
   const fetchSpec = async () => {
     try {
@@ -58,6 +60,7 @@ export default function PropertyLiveUpdatePage({ params }: { params: Promise<{ i
         }]
       });
       setPropertyHistory(res.data ?? []);
+      setTaskFilter(ALL_TASKS);
     } catch (err) {
       console.error("Failed to fetch property history:", err);
     }
@@ -69,6 +72,15 @@ export default function PropertyLiveUpdatePage({ params }: { params: Promise<{ i
     ) ?? [],
     [spec]
   );
+
+  const availableTasks = useMemo(() => {
+    const tasks = new Set<string>();
+    for (const obs of propertyHistory) {
+      const task = obs.metadata?.task;
+      if (task) tasks.add(task);
+    }
+    return Array.from(tasks).sort();
+  }, [propertyHistory]);
 
   const filteredProperties = useMemo(() => {
     const q = search.trim();
@@ -117,15 +129,50 @@ export default function PropertyLiveUpdatePage({ params }: { params: Promise<{ i
 
       {/* Right - Chart view */}
       <div className="flex-1 bg-gray-800 rounded p-4">
-        <h2 className="text-white text-lg font-semibold mb-4">
-          Live Chart for <span className="text-blue-300">{selectedProperty}</span>
-        </h2>
+        <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
+          <h2 className="text-white text-lg font-semibold">
+            Live Chart for <span className="text-blue-300">{selectedProperty}</span>
+          </h2>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-gray-300">Task</label>
+              <select
+                value={taskFilter}
+                onChange={(e) => setTaskFilter(e.target.value)}
+                className="bg-gray-800 text-white border border-gray-700 rounded px-2 py-1 text-sm"
+              >
+                <option value={ALL_TASKS}>All</option>
+                {availableTasks.map((task) => (
+                  <option key={task} value={task}>{task}</option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex items-center gap-1 text-sm">
+              <button
+                onClick={() => setAgeUnit("months")}
+                className={`px-2 py-1 rounded ${ageUnit === "months" ? "bg-blue-700 text-white" : "bg-gray-800 text-gray-300"}`}
+              >
+                Months
+              </button>
+              <button
+                onClick={() => setAgeUnit("years")}
+                className={`px-2 py-1 rounded ${ageUnit === "years" ? "bg-blue-700 text-white" : "bg-gray-800 text-gray-300"}`}
+              >
+                Years
+              </button>
+            </div>
+          </div>
+        </div>
 
         {selectedProperty ? (
           <LiveLineChart
             dtId={id}
             pName={selectedProperty}
             history={propertyHistory}
+            taskFilter={taskFilter}
+            ageUnit={ageUnit}
           />
         ) : (
           <p className="text-white">Select a property to view its live chart.</p>

--- a/src/components/LiveLineChart.tsx
+++ b/src/components/LiveLineChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import {
   LineChart,
   Line,
@@ -10,50 +11,113 @@ import {
 } from "recharts";
 import { PropertyObservationDocument } from "@/lib/api/schema";
 
+export type AgeUnit = "months" | "years";
+
+export const ALL_TASKS = "all";
+
 interface LiveLineChartProps {
   dtId: string;
   pName: string;
-  history: PropertyObservationDocument[]
+  history: PropertyObservationDocument[];
+  taskFilter: string;
+  ageUnit: AgeUnit;
 }
 
-export default function LiveLineChart({ dtId, pName, history }: LiveLineChartProps) {
-  const chartData = history
+// Age values (months, or years once converted) stay well under this bound;
+// epoch timestamps used as the timeField fallback are always far above it.
+const EPOCH_MAGNITUDE_THRESHOLD = 1e6;
 
-  if (chartData.length === 0 ) {
+function parseAgeMonths(observation: PropertyObservationDocument): number | null {
+  const raw = observation.metadata?.age;
+  if (raw === undefined) return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function extractValue(observation: PropertyObservationDocument): number | null {
+  const value = observation.value as { value?: unknown } | undefined;
+  const raw = value?.value;
+  if (typeof raw === "number") return raw;
+  if (typeof raw === "boolean") return Number(raw);
+  return null;
+}
+
+function formatAge(ageMonths: number, unit: AgeUnit): string {
+  const converted = unit === "years" ? ageMonths / 12 : ageMonths;
+  return `${converted.toFixed(1)} ${unit === "years" ? "yr" : "mo"}`;
+}
+
+export default function LiveLineChart({ history, taskFilter, ageUnit }: LiveLineChartProps) {
+  const chartData = useMemo(() => {
+    const filtered = taskFilter === ALL_TASKS
+      ? history
+      : history.filter((obs) => obs.metadata?.task === taskFilter);
+
+    const points = filtered.map((obs) => {
+      const ageMonths = parseAgeMonths(obs);
+      const hasAge = ageMonths !== null;
+      const x = hasAge ? ageMonths! : new Date(obs.timeField).getTime();
+      return {
+        x: hasAge && ageUnit === "years" ? x / 12 : x,
+        hasAge,
+        ageMonths,
+        timeField: obs.timeField,
+        task: obs.metadata?.task ?? null,
+        value: extractValue(obs),
+      };
+    });
+
+    return points.sort((a, b) => a.x - b.x);
+  }, [history, taskFilter, ageUnit]);
+
+  if (chartData.length === 0) {
     return <div>No data to display</div>;
   }
 
-  return (
-  <div>
-    <ResponsiveContainer width="100%" height={300}>
-      <LineChart data={chartData}>
+  const latest = chartData[chartData.length - 1];
 
-        <XAxis
-          dataKey="timeField"
-          stroke="#ccc"
-          tickFormatter={(ts) =>
-            typeof ts === "number"
-              ? new Date(ts).toLocaleTimeString()
-              : ts
-          }
-        />
-        <YAxis stroke="#ccc" />
-        <Tooltip
-          labelFormatter={(ts) =>
-            typeof ts === "number"
-              ? new Date(ts).toLocaleTimeString()
-              : ts
-          }
-        />
-        <Line
+  return (
+    <div>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={chartData}>
+          <XAxis
+            dataKey="x"
+            type="number"
+            domain={["dataMin", "dataMax"]}
+            stroke="#ccc"
+            tickFormatter={(x: number) =>
+              x > EPOCH_MAGNITUDE_THRESHOLD
+                ? new Date(x).toLocaleTimeString()
+                : `${x.toFixed(1)} ${ageUnit === "years" ? "yr" : "mo"}`
+            }
+          />
+          <YAxis stroke="#ccc" />
+          <Tooltip
+            labelFormatter={(x: number, payload) => {
+              const point = payload?.[0]?.payload as (typeof chartData)[number] | undefined;
+              if (point?.hasAge) return `Age: ${formatAge(point.ageMonths!, ageUnit)}`;
+              return new Date(x).toLocaleString();
+            }}
+          />
+          <Line
             type="monotone"
-            dataKey={"value.value"}
+            dataKey="value"
             stroke="#00bfff"
             strokeWidth={2}
             dot={true}
           />
-      </LineChart>
-    </ResponsiveContainer>
+        </LineChart>
+      </ResponsiveContainer>
+
+      <div className="mt-3 text-sm text-gray-300 flex flex-wrap gap-6">
+        <span>Latest value: <span className="text-white">{latest.value ?? "—"}</span></span>
+        <span>
+          Age: <span className="text-white">
+            {latest.ageMonths !== null ? formatAge(latest.ageMonths, ageUnit) : "—"}
+          </span>
+        </span>
+        <span>Task: <span className="text-white">{latest.task ?? "—"}</span></span>
+      </div>
     </div>
   );
 }

--- a/src/lib/api/schema.d.ts
+++ b/src/lib/api/schema.d.ts
@@ -769,6 +769,9 @@ export interface components {
             /** Format: date-time */
             timeField: string;
             value: components["schemas"]["PropertyValue"];
+            metadata: {
+                [key: string]: string;
+            };
         };
         /** io.github.whdt.core.hdt.model.property.PropertyObservation */
         PropertyObservation: {


### PR DESCRIPTION
- Regenerate schema.d.ts from persistence-service's updated openapi.yaml, which now requires metadata (age/task) on PropertyObservationDocument.
- LiveLineChart now plots observations by metadata.age (months), sorted ascending, falling back to timeField when age is absent per-observation.
- Add a task filter (defaulting to "all") driven by distinct metadata.task values in the fetched history, and a months/years toggle that converts the age axis and the latest-observation age readout.