### PR TITLE
Add population stats matrix and task/sex cohort filters to Search DTs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -444,6 +444,20 @@ paths:
           description: Property not found
         '500':
           description: Failed to update tags
+  /properties/names:
+    get:
+      operationId: properties/names
+      summary: List distinct Property names
+      description: Returns the distinct set of propertyName values across all Property specs
+      responses:
+        '200':
+          description: Distinct property names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
   /observations/batch:
     post:
       operationId: observations/batch/insert
@@ -855,6 +869,13 @@ components:
         to:
           type: string
           format: date-time
+          nullable: true
+        metadataFilters:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
           nullable: true
     mqtt-physical-interface:
       type: object

--- a/src/app/query-builder/panels/ObservationQueryPanel.tsx
+++ b/src/app/query-builder/panels/ObservationQueryPanel.tsx
@@ -13,6 +13,7 @@ import { FilterOperator, toWhdtComparisonOp } from "@/app/query-builder/types/qu
 import { HdtScopeSelector } from "@/components/query/HdtScopeSelector";
 import { LoadingOverlay } from "@/components/common/LoadingOverlay";
 import { CohortTable } from "@/components/query/cohort/CohortTable";
+import { PopulationStatsMatrix } from "@/components/query/cohort/PopulationStatsMatrix";
 import { deriveCohortColumns } from "@/components/query/cohort/shared";
 import { exportCohortToExcel } from "@/components/query/cohort/exportToExcel";
 
@@ -43,6 +44,8 @@ export function ObservationQueryPanel() {
   const [models, setModels] = useState<string[]>([]);
   const [modelNames, setModelNames] = useState<string[]>([]);
   const [filters, setFilters] = useState<ComparisonFilter[]>([]);
+  const [task, setTask] = useState("");
+  const [sex, setSex] = useState("");
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
   const [results, setResults] = useState<Record<string, unknown>[]>([]);
@@ -50,6 +53,7 @@ export function ObservationQueryPanel() {
   const [error, setError] = useState<string | null>(null);
   const [empty, setEmpty] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [showPerDtBreakdown, setShowPerDtBreakdown] = useState(false);
 
   useEffect(() => {
     api.GET("/models").then((res) => {
@@ -83,6 +87,7 @@ export function ObservationQueryPanel() {
     setEmpty(false);
     setResults([]);
     setCohortResult(null);
+    setShowPerDtBreakdown(false);
     setLoading(true);
 
     try {
@@ -118,11 +123,16 @@ export function ObservationQueryPanel() {
             value: parseValue(f.value, f.valueType),
           }));
 
+        const metadataFilters: Record<string, string[]> = {};
+        if (task.trim() !== "") metadataFilters.task = [task.trim()];
+        if (sex.trim() !== "") metadataFilters.sex = [sex.trim()];
+
         const body: PropertiesByComparisonsRequestDto = {
           comparisons,
           modelNames: models,
           ...(from ? { from: toIso(from) } : {}),
           ...(to ? { to: toIso(to) } : {}),
+          ...(Object.keys(metadataFilters).length > 0 ? { metadataFilters } : {}),
         };
 
         const { data, error: err } = await api.POST("/query/cohort", { body });
@@ -315,6 +325,35 @@ export function ObservationQueryPanel() {
           </div>
         )}
 
+        {/* Cohort metadata filters (search mode) */}
+        {mode === "search" && (
+          <div className="mb-6 p-4 bg-gray-700 rounded-lg">
+            <label className="block mb-2 font-semibold">Cohort Filters</label>
+            <div className="flex gap-4 flex-wrap">
+              <div className="flex flex-col gap-1">
+                <span className="text-sm text-gray-400">Task</span>
+                <input
+                  type="text"
+                  className="p-2 bg-gray-800 border border-gray-600 rounded"
+                  placeholder="e.g. walking"
+                  value={task}
+                  onChange={(e) => setTask(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <span className="text-sm text-gray-400">Sex</span>
+                <input
+                  type="text"
+                  className="p-2 bg-gray-800 border border-gray-600 rounded"
+                  placeholder="e.g. female"
+                  value={sex}
+                  onChange={(e) => setSex(e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Time window */}
         <div className="mb-6 p-4 bg-gray-700 rounded-lg">
           <label className="block mb-2 font-semibold">Time Window (optional)</label>
@@ -409,9 +448,12 @@ export function ObservationQueryPanel() {
 
         {mode === "search" && cohortResult && (
           <div>
-            <h2 className="text-lg font-bold mb-4">Cohort Results</h2>
+            <h2 className="text-lg font-bold mb-4">Population Stats</h2>
 
-            <CohortTable data={cohortResult} filteredPropertyNames={filteredPropertyNames} />
+            <PopulationStatsMatrix
+              populationStats={cohortResult.populationStats}
+              filteredPropertyNames={filteredPropertyNames}
+            />
 
             <button
               onClick={exportCohortToExcelFile}
@@ -419,6 +461,21 @@ export function ObservationQueryPanel() {
             >
               Export Excel
             </button>
+
+            <div className="mt-8">
+              <button
+                onClick={() => setShowPerDtBreakdown((v) => !v)}
+                className="bg-gray-600 hover:bg-gray-500 transition px-4 py-2 rounded text-sm font-semibold"
+              >
+                {showPerDtBreakdown ? "▾" : "▸"} Per-DT breakdown
+              </button>
+
+              {showPerDtBreakdown && (
+                <div className="mt-4">
+                  <CohortTable data={cohortResult} filteredPropertyNames={filteredPropertyNames} />
+                </div>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/src/components/query/cohort/CohortTable.tsx
+++ b/src/components/query/cohort/CohortTable.tsx
@@ -3,10 +3,12 @@
 import { Fragment, useMemo, useState } from "react";
 import { CohortResult } from "@/lib/api/schema";
 import {
+  COUNT_LABEL,
   STAT_COLS,
   STAT_LABELS,
   cellFor,
   deriveCohortColumns,
+  fmtCount,
   fmtStat,
   rawCellValue,
 } from "./shared";
@@ -59,7 +61,7 @@ export function CohortTable({
                 return (
                   <th
                     key={col.name}
-                    colSpan={open ? 1 + STAT_COLS.length : 1}
+                    colSpan={open ? 2 + STAT_COLS.length : 1}
                     className={`px-4 py-2 text-left cursor-pointer select-none whitespace-nowrap ${
                       col.filtered ? "bg-blue-900/60" : ""
                     }`}
@@ -82,6 +84,11 @@ export function CohortTable({
                     >
                       Value
                     </th>
+                    {open && (
+                      <th className="px-4 py-2 text-left text-xs font-normal whitespace-nowrap">
+                        {COUNT_LABEL}
+                      </th>
+                    )}
                     {open &&
                       STAT_COLS.map((s) => (
                         <th
@@ -106,6 +113,7 @@ export function CohortTable({
                 return (
                   <Fragment key={col.name}>
                     <td className="px-4 py-2">—</td>
+                    {open && <td className="px-4 py-2">{fmtCount(stats)}</td>}
                     {open &&
                       STAT_COLS.map((s) => (
                         <td key={s} className="px-4 py-2">
@@ -128,6 +136,7 @@ export function CohortTable({
                     return (
                       <Fragment key={col.name}>
                         <td className="px-4 py-2">{value == null ? "—" : String(value)}</td>
+                        {open && <td className="px-4 py-2">{fmtCount(cell)}</td>}
                         {open &&
                           STAT_COLS.map((s) => (
                             <td key={s} className="px-4 py-2">

--- a/src/components/query/cohort/PopulationStatsMatrix.tsx
+++ b/src/components/query/cohort/PopulationStatsMatrix.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useMemo } from "react";
+import { PropertyPopulationStats } from "@/lib/api/schema";
+import { COUNT_LABEL, STAT_COLS, STAT_LABELS, deriveCohortColumns, fmtCount, fmtStat } from "./shared";
+
+export function PopulationStatsMatrix({
+  populationStats,
+  filteredPropertyNames,
+}: {
+  populationStats: PropertyPopulationStats[];
+  filteredPropertyNames: string[];
+}) {
+  const columns = useMemo(
+    () => deriveCohortColumns(populationStats, filteredPropertyNames),
+    [populationStats, filteredPropertyNames]
+  );
+  const statsByName = useMemo(
+    () => new Map(populationStats.map((s) => [s.propertyName, s])),
+    [populationStats]
+  );
+
+  return (
+    <div className="overflow-x-auto rounded-lg shadow-md">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-700">
+          <tr>
+            <th className="px-4 py-2 text-left">Property</th>
+            <th className="px-4 py-2 text-left whitespace-nowrap">{COUNT_LABEL}</th>
+            {STAT_COLS.map((s) => (
+              <th key={s} className="px-4 py-2 text-left whitespace-nowrap">
+                {STAT_LABELS[s]}
+              </th>
+            ))}
+          </tr>
+        </thead>
+
+        <tbody>
+          {columns.map((col) => {
+            const stats = statsByName.get(col.name);
+            return (
+              <tr
+                key={col.name}
+                className={`border-t border-gray-700 hover:bg-gray-700 ${
+                  col.filtered ? "bg-blue-900/40" : ""
+                }`}
+              >
+                <td className="px-4 py-2 font-semibold whitespace-nowrap">{col.name}</td>
+                <td className="px-4 py-2">{fmtCount(stats)}</td>
+                {STAT_COLS.map((s) => (
+                  <td key={s} className="px-4 py-2">
+                    {fmtStat(stats, s)}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/query/cohort/exportToExcel.ts
+++ b/src/components/query/cohort/exportToExcel.ts
@@ -1,15 +1,6 @@
 import * as XLSX from "xlsx";
 import { CohortResult } from "@/lib/api/schema";
-import {
-  CohortColumn,
-  STAT_COLS,
-  STAT_LABELS,
-  cellFor,
-  fmtStat,
-  rawCellValue,
-} from "./shared";
-
-type CellRange = { s: { r: number; c: number }; e: { r: number; c: number } };
+import { CohortColumn, COUNT_LABEL, STAT_COLS, STAT_LABELS, fmtCount, fmtStat } from "./shared";
 
 export function exportCohortToExcel(
   data: CohortResult,
@@ -18,46 +9,19 @@ export function exportCohortToExcel(
 ) {
   const popStatsByName = new Map(data.populationStats.map((s) => [s.propertyName, s]));
 
-  const header1: (string | number)[] = ["DT"];
-  const header2: (string | number)[] = [""];
-  columns.forEach((col) => {
-    header1.push(col.name, ...STAT_COLS.map(() => ""));
-    header2.push("Value", ...STAT_COLS.map((s) => STAT_LABELS[s]));
-  });
+  const header: (string | number)[] = ["Property", COUNT_LABEL, ...STAT_COLS.map((s) => STAT_LABELS[s])];
 
-  const popRow: (string | number)[] = ["Population"];
-  columns.forEach((col) => {
+  const rows = columns.map((col) => {
     const stats = popStatsByName.get(col.name);
-    popRow.push("—", ...STAT_COLS.map((s) => fmtStat(stats, s)));
+    return [col.name, fmtCount(stats), ...STAT_COLS.map((s) => fmtStat(stats, s))];
   });
 
-  const dataRows = data.rows.map((row) => {
-    const cells: (string | number)[] = [row.hdtId];
-    columns.forEach((col) => {
-      const cell = cellFor(row, col.name);
-      const value = rawCellValue(cell);
-      cells.push(
-        value == null ? "—" : typeof value === "boolean" ? String(value) : value,
-        ...STAT_COLS.map((s) => fmtStat(cell, s))
-      );
-    });
-    return cells;
-  });
-
-  const aoa = [header1, header2, popRow, ...dataRows];
+  const aoa = [header, ...rows];
   const ws = XLSX.utils.aoa_to_sheet(aoa);
-
-  const merges: CellRange[] = [{ s: { r: 0, c: 0 }, e: { r: 1, c: 0 } }];
-  let col = 1;
-  columns.forEach(() => {
-    merges.push({ s: { r: 0, c: col }, e: { r: 0, c: col + STAT_COLS.length } });
-    col += STAT_COLS.length + 1;
-  });
-  ws["!merges"] = merges;
 
   const range = XLSX.utils.decode_range(ws["!ref"] ?? "A1");
   for (let c = range.s.c; c <= range.e.c; c++) {
-    const addr = XLSX.utils.encode_cell({ r: 2, c });
+    const addr = XLSX.utils.encode_cell({ r: 0, c });
     const target = ws[addr];
     if (target) {
       target.s = { font: { bold: true } };
@@ -65,6 +29,6 @@ export function exportCohortToExcel(
   }
 
   const wb = XLSX.utils.book_new();
-  XLSX.utils.book_append_sheet(wb, ws, "Cohort");
+  XLSX.utils.book_append_sheet(wb, ws, "Population Stats");
   XLSX.writeFile(wb, filename);
 }

--- a/src/components/query/cohort/shared.ts
+++ b/src/components/query/cohort/shared.ts
@@ -1,18 +1,19 @@
 import { CohortPropertyCell, CohortRow } from "@/lib/api/schema";
 import { distinct } from "@/util/utils";
 
-export const STAT_COLS = ["count", "avg", "min", "max", "median", "p25", "p75"] as const;
+export const STAT_COLS = ["min", "p25", "median", "avg", "p75", "max"] as const;
 export type StatCol = (typeof STAT_COLS)[number];
 
 export const STAT_LABELS: Record<StatCol, string> = {
-  count: "Count",
-  avg: "Avg",
   min: "Min",
-  max: "Max",
+  p25: "25%",
   median: "Median",
-  p25: "P25",
-  p75: "P75",
+  avg: "Mean",
+  p75: "75%",
+  max: "Max",
 };
+
+export const COUNT_LABEL = "Count";
 
 export type StatBearing = {
   count: number;
@@ -28,7 +29,11 @@ export const fmt = (n?: number | null) => (n == null ? "—" : n.toFixed(2));
 
 export function fmtStat(source: StatBearing | undefined, stat: StatCol): string {
   if (!source) return "—";
-  return stat === "count" ? String(source.count) : fmt(source[stat]);
+  return fmt(source[stat]);
+}
+
+export function fmtCount(source: StatBearing | undefined): string {
+  return source ? String(source.count) : "—";
 }
 
 export type CohortColumn = { name: string; filtered: boolean };

--- a/src/lib/api/schema.d.ts
+++ b/src/lib/api/schema.d.ts
@@ -296,6 +296,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/properties/names": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List distinct Property names
+         * @description Returns the distinct set of propertyName values across all Property specs
+         */
+        get: operations["properties/names"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/observations/batch": {
         parameters: {
             query?: never;
@@ -585,6 +605,9 @@ export interface components {
             from?: string | null;
             /** Format: date-time */
             to?: string | null;
+            metadataFilters?: {
+                [key: string]: string[];
+            } | null;
         };
         /** mqtt-physical-interface */
         "mqtt-physical-interface": {
@@ -1695,6 +1718,26 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    "properties/names": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Distinct property names */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string[];
+                };
             };
         };
     };


### PR DESCRIPTION
Sync openapi.yaml from persistence-service and regenerate schema.d.ts to pick up PropertiesByComparisonsRequestDto.metadataFilters. Render cohortResult.populationStats as the primary property x stat matrix (Property, Count, Min, 25%, Median, Mean, 75%, Max), with the existing per-DT CohortTable moved into a collapsible "Per-DT breakdown" and the Excel export pointed at the matrix instead of the per-DT grid.


Claude-Session: https://claude.ai/code/session_01LYYHUgGBef4RFhZqZaobVu